### PR TITLE
fix(new_planning_launch): fix package.xml

### DIFF
--- a/autoware_new_planning_launch/package.xml
+++ b/autoware_new_planning_launch/package.xml
@@ -19,7 +19,7 @@
   <exec_depend>autoware_trajectory_concatenater</exec_depend>
   <exec_depend>autoware_trajectory_ranker</exec_depend>
   <exec_depend>autoware_valid_trajectory_filter</exec_depend>
-  <exec_depend>glog_component</exec_depend>
+  <exec_depend>autoware_glog_component</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>


### PR DESCRIPTION
The autoware_prefix is missing for glog_component.
The error occurring is ``autoware_new_planning_launch: Cannot locate rosdep definition for [glog_component]` `.
This PR, adds autoware prefix.
