### PR TITLE
fix(common): normalize metrics when candidate path size is 1

### DIFF
--- a/autoware_trajectory_adaptor/src/node.cpp
+++ b/autoware_trajectory_adaptor/src/node.cpp
@@ -47,7 +47,7 @@ void TrajectoryAdaptorNode::process(const InputMsgType::ConstSharedPtr msg)
                                                       : generator_itr->generator_name.data;
   };
 
-  RCLCPP_INFO_STREAM(
+  RCLCPP_DEBUG_STREAM(
     this->get_logger(), "best generator:" << best_generator(trajectory_itr->generator_id)
                                           << " score:" << trajectory_itr->score);
 

--- a/autoware_trajectory_selector_common/src/evaluation.cpp
+++ b/autoware_trajectory_selector_common/src/evaluation.cpp
@@ -78,7 +78,15 @@ void Evaluator::evaluate()
 
 void Evaluator::normalize()
 {
-  if (results_.size() < 2) return;
+  if(results_.empty()) return;
+
+  if (results_.size() < 2) {
+    const auto data = results_.front();
+    for(const auto & plugin : plugins_) {
+      data->normalize(0.0, data->score(plugin->index()), plugin->index());
+    }
+    return;
+  }
 
   const auto range = [this](const size_t index) {
     double min = std::numeric_limits<double>::max();

--- a/autoware_trajectory_selector_common/src/evaluation.cpp
+++ b/autoware_trajectory_selector_common/src/evaluation.cpp
@@ -209,7 +209,7 @@ void Evaluator::show() const
     ss << plugin->name() << ":" << " mean:" << mean << " std:" << std::sqrt(dev) << "\n";
   }
   ss << "total:" << best_data->total();
-  RCLCPP_INFO_STREAM(rclcpp::get_logger(__func__), ss.str());
+  RCLCPP_DEBUG_STREAM(rclcpp::get_logger(__func__), ss.str());
 }
 
 auto Evaluator::marker() const -> std::shared_ptr<MarkerArray>


### PR DESCRIPTION
Currently, the normalize function does not normalize each metric when there is a single candidate path.
This PR fixes the issue.
Furthermore the logging level is changed to `DEBUG`, in order to keep the terminal clean.
(The metrics or score is trying to be visualized by lichtblick) 