### PR TITLE
fix(ranker, metrics): use parameter instead of hard code

### DIFF
--- a/autoware_trajectory_metrics/src/metrics.cpp
+++ b/autoware_trajectory_metrics/src/metrics.cpp
@@ -43,12 +43,14 @@ void LongitudinalJerk::evaluate(const std::shared_ptr<DataInterface> & result) c
   if (result->points()->size() < 2) return;
 
   std::vector<double> metric;
+  constexpr double epsilon = 1.0e-3;
+  const double time_resolution = resolution() > epsilon ? resolution() : epsilon;
 
   metric.reserve(result->points()->size());
   for (size_t i = 0; i < result->points()->size() - 1; i++) {
     const auto jerk =
       (result->points()->at(i + 1).acceleration_mps2 - result->points()->at(i).acceleration_mps2) /
-      0.5;
+      time_resolution;
     metric.push_back(std::abs(jerk));
   }
   metric.push_back(metric.back());

--- a/autoware_trajectory_ranker/src/node.cpp
+++ b/autoware_trajectory_ranker/src/node.cpp
@@ -90,12 +90,14 @@ auto TrajectoryRankerNode::score(const Trajectories::ConstSharedPtr msg)
 
   evaluator_->clear();
 
+  const auto params = parameters();
+
   for (const auto & t : msg->trajectories) {
     // TODO(satoshi-ota): remove this lambda.
-    const auto points = [&t, &msg, &odometry_ptr]() {
+    const auto points = [&t, &msg, &odometry_ptr, &params]() {
       return generator_name(t.generator_id, msg->generator_info) == "frenet_planner"
                ? t.points
-               : utils::sampling(t.points, odometry_ptr->pose.pose, 20, 0.5);
+               : utils::sampling(t.points, odometry_ptr->pose.pose, params->sample_num, params->resolution);
     }();
 
     const auto core_data = std::make_shared<CoreData>(
@@ -105,7 +107,7 @@ auto TrajectoryRankerNode::score(const Trajectories::ConstSharedPtr msg)
     evaluator_->add(core_data);
   }
 
-  const auto best_data = evaluator_->best(parameters());
+  const auto best_data = evaluator_->best(params);
   previous_points_ = best_data == nullptr ? nullptr : best_data->points();
 
   evaluator_->show();

--- a/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/interface/metrics_interface.hpp
+++ b/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/interface/metrics_interface.hpp
@@ -43,7 +43,11 @@ public:
 
   virtual bool is_deviation() const = 0;
 
-  void init(const std::shared_ptr<VehicleInfo> & vehicle_info) { vehicle_info_ = vehicle_info; }
+  void init(const std::shared_ptr<VehicleInfo> & vehicle_info, const double resolution)
+  {
+    vehicle_info_ = vehicle_info;
+    resolution_ = resolution;
+  }
 
   void set_index(const size_t index) { index_ = index; }
 
@@ -53,6 +57,7 @@ public:
 
 protected:
   auto vehicle_info() const -> std::shared_ptr<VehicleInfo> { return vehicle_info_; }
+  double resolution() const { return resolution_; }
 
 private:
   std::shared_ptr<VehicleInfo> vehicle_info_;
@@ -60,6 +65,8 @@ private:
   std::string name_;
 
   size_t index_;
+
+  double resolution_;
 };
 
 }  // namespace autoware::trajectory_selector

--- a/autoware_trajectory_selector_common/src/evaluation.cpp
+++ b/autoware_trajectory_selector_common/src/evaluation.cpp
@@ -144,14 +144,6 @@ void Evaluator::add(const std::shared_ptr<CoreData> & core_data)
   results_.push_back(ptr);
 }
 
-// TODO(satoshi-ota): remove this function.
-// void Evaluator::setup(const std::shared_ptr<TrajectoryPoints> & previous_points)
-// {
-//   std::for_each(results_.begin(), results_.end(), [&previous_points](const auto & result) {
-//     result->setup(previous_points);
-//   });
-// }
-
 auto Evaluator::best(
   const std::shared_ptr<EvaluatorParameters> & parameters,
   const std::string & exclude) -> std::shared_ptr<DataInterface>


### PR DESCRIPTION
Sampling number and time resolution used for trajectory evaluation was hard coded.
This has been fixed in this PR.