### PR TITLE
fix(concatenator): spelling

### DIFF
--- a/autoware_new_planning_framework/package.xml
+++ b/autoware_new_planning_framework/package.xml
@@ -17,7 +17,7 @@
   <depend>autoware_new_planning_msgs_converter</depend>
   <depend>autoware_offline_evaluation_tools</depend>
   <depend>autoware_trajectory_adaptor</depend>
-  <depend>autoware_trajectory_concatenater</depend>
+  <depend>autoware_trajectory_concatenator</depend>
   <depend>autoware_trajectory_metrics</depend>
   <depend>autoware_trajectory_ranker</depend>
   <depend>autoware_trajectory_selector_common</depend>

--- a/autoware_new_planning_launch/launch/selector.launch.xml
+++ b/autoware_new_planning_launch/launch/selector.launch.xml
@@ -25,7 +25,7 @@
 
   <node_container pkg="rclcpp_components" exec="$(var container_type)" name="trajectory_selector_container" namespace="" output="both">
     <!-- concatenate multiple topics -->
-    <composable_node pkg="autoware_trajectory_concatenater" plugin="autoware::trajectory_selector::trajectory_concatenater::TrajectoryConcatenaterNode" name="trajectory_concatenater" namespace="">
+    <composable_node pkg="autoware_trajectory_concatenator" plugin="autoware::trajectory_selector::trajectory_concatenator::TrajectoryconcatenatorNode" name="trajectory_concatenator" namespace="">
       <remap from="~/input/trajectories" to="$(var selector_component_input)"/>
       <remap from="~/output/trajectories" to="/planning/trajectory_selector/concatenate/trajectories"/>
       <!-- composable node config -->

--- a/autoware_new_planning_launch/launch/selector.launch.xml
+++ b/autoware_new_planning_launch/launch/selector.launch.xml
@@ -25,7 +25,7 @@
 
   <node_container pkg="rclcpp_components" exec="$(var container_type)" name="trajectory_selector_container" namespace="" output="both">
     <!-- concatenate multiple topics -->
-    <composable_node pkg="autoware_trajectory_concatenator" plugin="autoware::trajectory_selector::trajectory_concatenator::TrajectoryconcatenatorNode" name="trajectory_concatenator" namespace="">
+    <composable_node pkg="autoware_trajectory_concatenator" plugin="autoware::trajectory_selector::trajectory_concatenator::TrajectoryConcatenatorNode" name="trajectory_concatenator" namespace="">
       <remap from="~/input/trajectories" to="$(var selector_component_input)"/>
       <remap from="~/output/trajectories" to="/planning/trajectory_selector/concatenate/trajectories"/>
       <!-- composable node config -->

--- a/autoware_new_planning_launch/package.xml
+++ b/autoware_new_planning_launch/package.xml
@@ -16,7 +16,7 @@
   <exec_depend>autoware_feasible_trajectory_filter</exec_depend>
   <exec_depend>autoware_new_planning_msgs_converter</exec_depend>
   <exec_depend>autoware_trajectory_adaptor</exec_depend>
-  <exec_depend>autoware_trajectory_concatenater</exec_depend>
+  <exec_depend>autoware_trajectory_concatenator</exec_depend>
   <exec_depend>autoware_trajectory_ranker</exec_depend>
   <exec_depend>autoware_valid_trajectory_filter</exec_depend>
   <exec_depend>autoware_glog_component</exec_depend>

--- a/autoware_trajectory_concatenater/README.md
+++ b/autoware_trajectory_concatenater/README.md
@@ -1,1 +1,0 @@
-# Trajectory Concatenater

--- a/autoware_trajectory_concatenator/CMakeLists.txt
+++ b/autoware_trajectory_concatenator/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(autoware_trajectory_concatenater)
+project(autoware_trajectory_concatenator)
 
 find_package(autoware_cmake REQUIRED)
 autoware_package()
@@ -13,7 +13,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "autoware::trajectory_selector::trajectory_concatenater::TrajectoryConcatenaterNode"
+  PLUGIN "autoware::trajectory_selector::trajectory_concatenator::TrajectoryconcatenatorNode"
   EXECUTABLE ${PROJECT_NAME}_node
 )
 

--- a/autoware_trajectory_concatenator/CMakeLists.txt
+++ b/autoware_trajectory_concatenator/CMakeLists.txt
@@ -13,7 +13,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "autoware::trajectory_selector::trajectory_concatenator::TrajectoryconcatenatorNode"
+  PLUGIN "autoware::trajectory_selector::trajectory_concatenator::TrajectoryConcatenatorNode"
   EXECUTABLE ${PROJECT_NAME}_node
 )
 

--- a/autoware_trajectory_concatenator/README.md
+++ b/autoware_trajectory_concatenator/README.md
@@ -1,0 +1,1 @@
+# Trajectory concatenator

--- a/autoware_trajectory_concatenator/package.xml
+++ b/autoware_trajectory_concatenator/package.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
-  <name>autoware_trajectory_concatenater</name>
+  <name>autoware_trajectory_concatenator</name>
   <version>0.1.0</version>
-  <description>The autoware_trajectory_concatenater package</description>
+  <description>The autoware_trajectory_concatenator package</description>
   <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
   <license>Apache License 2.0</license>
 

--- a/autoware_trajectory_concatenator/src/node.cpp
+++ b/autoware_trajectory_concatenator/src/node.cpp
@@ -16,21 +16,21 @@
 
 #include <autoware/universe_utils/ros/uuid_helper.hpp>
 
-namespace autoware::trajectory_selector::trajectory_concatenater
+namespace autoware::trajectory_selector::trajectory_concatenator
 {
 
-TrajectoryConcatenaterNode::TrajectoryConcatenaterNode(const rclcpp::NodeOptions & node_options)
-: Node{"trajectory_concatenater_node", node_options},
+TrajectoryConcatenatorNode::TrajectoryConcatenatorNode(const rclcpp::NodeOptions & node_options)
+: Node{"trajectory_concatenator_node", node_options},
   timer_{rclcpp::create_timer(
-    this, get_clock(), 100ms, std::bind(&TrajectoryConcatenaterNode::publish, this))},
+    this, get_clock(), 100ms, std::bind(&TrajectoryConcatenatorNode::publish, this))},
   subs_trajectories_{this->create_subscription<Trajectories>(
     "~/input/trajectories", 1,
-    std::bind(&TrajectoryConcatenaterNode::on_trajectories, this, std::placeholders::_1))},
+    std::bind(&TrajectoryConcatenatorNode::on_trajectories, this, std::placeholders::_1))},
   pub_trajectores_{this->create_publisher<Trajectories>("~/output/trajectories", 1)}
 {
 }
 
-void TrajectoryConcatenaterNode::on_trajectories(const Trajectories::ConstSharedPtr msg)
+void TrajectoryConcatenatorNode::on_trajectories(const Trajectories::ConstSharedPtr msg)
 {
   std::lock_guard<std::mutex> lock(mutex_);
 
@@ -56,7 +56,7 @@ void TrajectoryConcatenaterNode::on_trajectories(const Trajectories::ConstShared
   }
 }
 
-void TrajectoryConcatenaterNode::publish()
+void TrajectoryConcatenatorNode::publish()
 {
   std::vector<Trajectory> trajectories{};
   std::vector<TrajectoryGeneratorInfo> generator_info{};
@@ -85,8 +85,8 @@ void TrajectoryConcatenaterNode::publish()
   pub_trajectores_->publish(output);
 }
 
-}  // namespace autoware::trajectory_selector::trajectory_concatenater
+}  // namespace autoware::trajectory_selector::trajectory_concatenator
 
 #include <rclcpp_components/register_node_macro.hpp>
 RCLCPP_COMPONENTS_REGISTER_NODE(
-  autoware::trajectory_selector::trajectory_concatenater::TrajectoryConcatenaterNode)
+  autoware::trajectory_selector::trajectory_concatenator::TrajectoryConcatenatorNode)

--- a/autoware_trajectory_concatenator/src/node.hpp
+++ b/autoware_trajectory_concatenator/src/node.hpp
@@ -25,7 +25,7 @@
 #include <string>
 #include <vector>
 
-namespace autoware::trajectory_selector::trajectory_concatenater
+namespace autoware::trajectory_selector::trajectory_concatenator
 {
 
 using namespace std::literals::chrono_literals;
@@ -33,10 +33,10 @@ using autoware_new_planning_msgs::msg::Trajectories;
 using autoware_new_planning_msgs::msg::Trajectory;
 using autoware_new_planning_msgs::msg::TrajectoryGeneratorInfo;
 
-class TrajectoryConcatenaterNode : public rclcpp::Node
+class TrajectoryConcatenatorNode : public rclcpp::Node
 {
 public:
-  explicit TrajectoryConcatenaterNode(const rclcpp::NodeOptions & node_options);
+  explicit TrajectoryConcatenatorNode(const rclcpp::NodeOptions & node_options);
 
 private:
   void on_trajectories(const Trajectories::ConstSharedPtr msg);
@@ -54,6 +54,6 @@ private:
   mutable std::mutex mutex_;
 };
 
-}  // namespace autoware::trajectory_selector::trajectory_concatenater
+}  // namespace autoware::trajectory_selector::trajectory_concatenator
 
 #endif  // NODE_HPP_


### PR DESCRIPTION
Fix spelling from concatenater to concatenator. 
(There seems to be vocab "concatenator", although it suggests spelling mistakes in certain dictionaries.
May be should change to trajectory_concatenate, but this would be out of subject right now.