### PR TITLE
refactor(msgs): delete TrajectoryPoint.msg

### DIFF
--- a/autoware_new_planning_msgs/CMakeLists.txt
+++ b/autoware_new_planning_msgs/CMakeLists.txt
@@ -8,7 +8,6 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/TrajectoryGeneratorInfo.msg"
   "msg/Trajectories.msg"
   "msg/Trajectory.msg"
-  # "msg/TrajectoryPoint.msg"
   DEPENDENCIES
   geometry_msgs
   std_msgs

--- a/autoware_new_planning_msgs/msg/TrajectoryPoint.msg
+++ b/autoware_new_planning_msgs/msg/TrajectoryPoint.msg
@@ -1,5 +1,0 @@
-builtin_interfaces/Duration time_from_start
-geometry_msgs/Pose pose
-float32 longitudinal_velocity_mps
-# float32 acceleration_mps2
-# float32 heading_rate_rps


### PR DESCRIPTION
There TrajectoryPoint.msg is not used currently as it uses [autoware_planning_msgs/TrajectoryPoint](https://github.com/autowarefoundation/autoware_msgs/blob/main/autoware_planning_msgs/msg/TrajectoryPoint.msg). 
Since it is unnecessary it would be removed.