### PR TITLE
feat(trajectory_ranker)!: publish best score trajectory

### DIFF
--- a/autoware_trajectory_ranker/src/node.cpp
+++ b/autoware_trajectory_ranker/src/node.cpp
@@ -38,6 +38,7 @@ auto generator_name(const UUID & uuid, const std::vector<TrajectoryGeneratorInfo
 TrajectoryRankerNode::TrajectoryRankerNode(const rclcpp::NodeOptions & node_options)
 : TrajectoryFilterInterface{"trajectory_ranker_node", node_options},
   pub_marker_{this->create_publisher<MarkerArray>("~/output/markers", 1)},
+  pub_score_debug_{this->create_publisher<ScoreDebug>("~/output/score_debug", 1)},
   listener_{std::make_unique<evaluation::ParamListener>(get_node_parameters_interface())},
   route_handler_{std::make_shared<RouteHandler>()},
   previous_points_{nullptr}
@@ -114,6 +115,7 @@ auto TrajectoryRankerNode::score(const Trajectories::ConstSharedPtr msg)
   evaluator_->show();
 
   pub_marker_->publish(*evaluator_->marker());
+  pub_score_debug_->publish(*evaluator_->score_debug(params));
 
   for (const auto & result : evaluator_->results()) {
     const auto scored_trajectory = autoware_new_planning_msgs::build<Trajectory>()

--- a/autoware_trajectory_ranker/src/node.hpp
+++ b/autoware_trajectory_ranker/src/node.hpp
@@ -21,6 +21,7 @@
 #include "autoware_trajectory_ranker_param.hpp"
 
 #include "autoware_new_planning_msgs/msg/trajectory.hpp"
+#include "autoware_new_planning_msgs/msg/score_debug.hpp"
 
 #include <memory>
 #include <vector>
@@ -29,6 +30,7 @@ namespace autoware::trajectory_selector::trajectory_ranker
 {
 
 using autoware_new_planning_msgs::msg::Trajectory;
+using autoware_new_planning_msgs::msg::ScoreDebug;
 
 class TrajectoryRankerNode : public TrajectoryFilterInterface
 {
@@ -53,6 +55,7 @@ private:
   rclcpp::Subscription<LaneletRoute>::SharedPtr sub_route_;
 
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_marker_;
+  rclcpp::Publisher<ScoreDebug>::SharedPtr pub_score_debug_;
 
   std::shared_ptr<Evaluator> evaluator_;
 

--- a/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/evaluation.hpp
+++ b/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/evaluation.hpp
@@ -19,6 +19,8 @@
 #include "autoware/trajectory_selector_common/interface/metrics_interface.hpp"
 #include "autoware/trajectory_selector_common/structs.hpp"
 #include "autoware/trajectory_selector_common/type_alias.hpp"
+#include "autoware_new_planning_msgs/msg/score_debug.hpp"
+#include <autoware_new_planning_msgs/msg/detail/score_debug__struct.hpp>
 
 #include <pluginlib/class_loader.hpp>
 
@@ -29,7 +31,7 @@
 
 namespace autoware::trajectory_selector
 {
-
+using autoware_new_planning_msgs::msg::ScoreDebug;
 class Evaluator
 {
 public:
@@ -66,6 +68,8 @@ public:
   void show() const;
 
   auto marker() const -> std::shared_ptr<MarkerArray>;
+
+  auto score_debug(const std::shared_ptr<EvaluatorParameters> & parameters) const -> std::shared_ptr<ScoreDebug>;
 
 protected:
   void pruning();

--- a/autoware_trajectory_selector_common/src/evaluation.cpp
+++ b/autoware_trajectory_selector_common/src/evaluation.cpp
@@ -20,6 +20,8 @@
 #include <autoware/universe_utils/ros/marker_helper.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_lanelet2_extension/visualization/visualization.hpp>
+#include <autoware_new_planning_msgs/msg/detail/score_debug__struct.hpp>
+#include <memory>
 
 namespace autoware::trajectory_selector
 {
@@ -274,5 +276,25 @@ auto Evaluator::marker() const -> std::shared_ptr<MarkerArray>
     &msg);
 
   return std::make_shared<MarkerArray>(msg);
+}
+
+auto Evaluator::score_debug(const std::shared_ptr<EvaluatorParameters> & parameters) const -> std::shared_ptr<ScoreDebug>
+{
+  ScoreDebug msg;
+
+  const auto best_data = best();
+
+  if(best_data != nullptr){
+    msg.generator_info.generator_name.data = best_data->tag();
+    msg.generator_info.generator_id = best_data->uuid();
+    msg.score = best_data->total();
+    for(const auto & plugin : plugins_) {
+      msg.metrics.push_back(plugin->name());
+      msg.metrics_value.push_back(best_data->score(plugin->index()));
+      msg.weights.push_back(parameters->score_weight.at(plugin->index()));
+
+    }
+  }
+  return std::make_shared<ScoreDebug>(msg);
 }
 }  // namespace autoware::trajectory_selector


### PR DESCRIPTION
Added a publisher that publishes the scoring debug message of the selected trajectory.
| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added | Pub | `/trajectory_ranker/output/score_debug` | `autoware_new_planning_msgs/msg/ScoreDebug`   | best trajectory score information for debug |

Checked by the command below:
`$ ros2 topic echo /trajectory_ranker/output/score_debug`
The output on terminal is
```
generator_info:
  generator_id:
    uuid:
    - 37
    - 105
    - 186
    - 130
    - 81
    - 85
    - 5
    - 118
    - 248
    - 128
    - 0
    - 45
    - 138
    - 88
    - 13
    - 73
  generator_name:
    data: __anon
score: 1.7000000476837158
metrics:
- LateralAcceleration
- LongitudinalJerk
- TravelDistance
- TimeToCollision
- LateralDeviation
- SteeringConsistency
metrics_value:
- 1.0
- 1.0
- 1.0
- 1.0
- 1.0
- 1.0
weights:
- 0.10000000149011612
- 0.10000000149011612
- 0.30000001192092896
- 0.6000000238418579
- 0.30000001192092896
- 0.30000001192092896
---
```