### PR TITLE
feat(trajectory_ranker)!: publish debug info for multiple trajectories

### DIFF
--- a/autoware_trajectory_ranker/src/node.cpp
+++ b/autoware_trajectory_ranker/src/node.cpp
@@ -38,7 +38,7 @@ auto generator_name(const UUID & uuid, const std::vector<TrajectoryGeneratorInfo
 TrajectoryRankerNode::TrajectoryRankerNode(const rclcpp::NodeOptions & node_options)
 : TrajectoryFilterInterface{"trajectory_ranker_node", node_options},
   pub_marker_{this->create_publisher<MarkerArray>("~/output/markers", 1)},
-  pub_score_debug_{this->create_publisher<EvaluationInfo>("~/output/score_debug", 1)},
+  pub_trajectories_debug_{this->create_publisher<TrajectoriesDebug>("~/output/score_debug", 1)},
   listener_{std::make_unique<evaluation::ParamListener>(get_node_parameters_interface())},
   route_handler_{std::make_shared<RouteHandler>()},
   previous_points_{nullptr}
@@ -115,7 +115,7 @@ auto TrajectoryRankerNode::score(const Trajectories::ConstSharedPtr msg)
   evaluator_->show();
 
   pub_marker_->publish(*evaluator_->marker());
-  pub_score_debug_->publish(*evaluator_->score_debug(params));
+  pub_trajectories_debug_->publish(*evaluator_->score_debug(params));
 
   for (const auto & result : evaluator_->results()) {
     const auto scored_trajectory = autoware_new_planning_msgs::build<Trajectory>()

--- a/autoware_trajectory_ranker/src/node.hpp
+++ b/autoware_trajectory_ranker/src/node.hpp
@@ -21,7 +21,7 @@
 #include "autoware_trajectory_ranker_param.hpp"
 
 #include "autoware_new_planning_msgs/msg/trajectory.hpp"
-#include "autoware_new_planning_msgs/msg/evaluation_info.hpp"
+#include "autoware_new_planning_msgs/msg/trajectories_debug.hpp"
 
 #include <memory>
 #include <vector>
@@ -30,7 +30,7 @@ namespace autoware::trajectory_selector::trajectory_ranker
 {
 
 using autoware_new_planning_msgs::msg::Trajectory;
-using autoware_new_planning_msgs::msg::EvaluationInfo;
+using autoware_new_planning_msgs::msg::TrajectoriesDebug;
 
 class TrajectoryRankerNode : public TrajectoryFilterInterface
 {
@@ -55,7 +55,7 @@ private:
   rclcpp::Subscription<LaneletRoute>::SharedPtr sub_route_;
 
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_marker_;
-  rclcpp::Publisher<EvaluationInfo>::SharedPtr pub_score_debug_;
+  rclcpp::Publisher<TrajectoriesDebug>::SharedPtr pub_trajectories_debug_;
 
   std::shared_ptr<Evaluator> evaluator_;
 

--- a/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/evaluation.hpp
+++ b/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/evaluation.hpp
@@ -19,7 +19,7 @@
 #include "autoware/trajectory_selector_common/interface/metrics_interface.hpp"
 #include "autoware/trajectory_selector_common/structs.hpp"
 #include "autoware/trajectory_selector_common/type_alias.hpp"
-#include "autoware_new_planning_msgs/msg/evaluation_info.hpp"
+#include "autoware_new_planning_msgs/msg/trajectories_debug.hpp"
 
 #include <pluginlib/class_loader.hpp>
 
@@ -30,7 +30,7 @@
 
 namespace autoware::trajectory_selector
 {
-using autoware_new_planning_msgs::msg::EvaluationInfo;
+using autoware_new_planning_msgs::msg::TrajectoriesDebug;
 class Evaluator
 {
 public:
@@ -68,7 +68,7 @@ public:
 
   auto marker() const -> std::shared_ptr<MarkerArray>;
 
-  auto score_debug(const std::shared_ptr<EvaluatorParameters> & parameters) const -> std::shared_ptr<EvaluationInfo>;
+  auto score_debug(const std::shared_ptr<EvaluatorParameters> & parameters) const -> std::shared_ptr<TrajectoriesDebug>;
 
 protected:
   void pruning();

--- a/autoware_trajectory_selector_common/src/evaluation.cpp
+++ b/autoware_trajectory_selector_common/src/evaluation.cpp
@@ -21,8 +21,7 @@
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_lanelet2_extension/visualization/visualization.hpp>
 
-#include <autoware_new_planning_msgs/msg/detail/evaluation_info__struct.hpp>
-#include <autoware_new_planning_msgs/msg/detail/trajectories_debug__struct.hpp>
+#include "autoware_new_planning_msgs/msg/evaluation_info.hpp"
 
 #include <memory>
 

--- a/autoware_trajectory_selector_common/src/evaluation.cpp
+++ b/autoware_trajectory_selector_common/src/evaluation.cpp
@@ -20,6 +20,10 @@
 #include <autoware/universe_utils/ros/marker_helper.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_lanelet2_extension/visualization/visualization.hpp>
+
+#include <autoware_new_planning_msgs/msg/detail/evaluation_info__struct.hpp>
+#include <autoware_new_planning_msgs/msg/detail/trajectories_debug__struct.hpp>
+
 #include <memory>
 
 namespace autoware::trajectory_selector
@@ -277,23 +281,30 @@ auto Evaluator::marker() const -> std::shared_ptr<MarkerArray>
   return std::make_shared<MarkerArray>(msg);
 }
 
-auto Evaluator::score_debug(const std::shared_ptr<EvaluatorParameters> & parameters) const -> std::shared_ptr<EvaluationInfo>
+auto Evaluator::score_debug(const std::shared_ptr<EvaluatorParameters> & parameters) const
+  -> std::shared_ptr<TrajectoriesDebug>
 {
-  EvaluationInfo msg;
+  TrajectoriesDebug msg;
 
-  const auto best_data = best();
+  msg.header = best()->header();
 
-  if(best_data != nullptr){
-    msg.generator_info.generator_name.data = best_data->tag();
-    msg.generator_info.generator_id = best_data->uuid();
-    msg.score = best_data->total();
-    for(const auto & plugin : plugins_) {
-      msg.metrics.push_back(plugin->name());
-      msg.metrics_value.push_back(best_data->score(plugin->index()));
-      msg.weights.push_back(parameters->score_weight.at(plugin->index()));
+  for (size_t i = 0; i < results_.size(); i++) {
+    autoware_new_planning_msgs::msg::EvaluationInfo eval_info;
 
+    const auto result = results_.at(i);
+    if (result == nullptr) continue;
+    eval_info.generator_info.generator_name.data = result->tag();
+    eval_info.generator_info.generator_id = result->uuid();
+    eval_info.score = result->total();
+
+    for (const auto & plugin : plugins_) {
+      eval_info.metrics.push_back(plugin->name());
+      eval_info.metrics_value.push_back(result->score(plugin->index()));
+      eval_info.weights.push_back(parameters->score_weight.at(plugin->index()));
     }
+    msg.scores.push_back(eval_info);
   }
-  return std::make_shared<EvaluationInfo>(msg);
+
+  return std::make_shared<TrajectoriesDebug>(msg);
 }
 }  // namespace autoware::trajectory_selector


### PR DESCRIPTION
## Description
With this PR all trajectories scoring information is published by using the message format introduced in https://github.com/tier4/new_planning_framework/pull/54.
| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Modified | Pub | `/trajectory_ranker/output/score_debug` | `autoware_new_planning_msgs/msg/TrajectoriesDebug`   | score information for each trajectory |

## How it was tested
Launched 2 planning components and checked that the debug message was published.
The raw message was successfully subscribed in lichtblick.
![Screenshot from 2025-01-31 00-23-51](https://github.com/user-attachments/assets/955807cf-83f4-4e42-8c01-edc95a939c05)
