### PR TITLE
fix(trajectory_selector_common): assign variable directly to msg header

### DIFF
--- a/autoware_trajectory_selector_common/src/evaluation.cpp
+++ b/autoware_trajectory_selector_common/src/evaluation.cpp
@@ -284,8 +284,8 @@ auto Evaluator::score_debug(const std::shared_ptr<EvaluatorParameters> & paramet
   -> std::shared_ptr<TrajectoriesDebug>
 {
   TrajectoriesDebug msg;
-
-  msg.header = best()->header();
+  msg.header.frame_id = "map";
+  msg.header.stamp = rclcpp::Clock{RCL_ROS_TIME}.now();
 
   for (size_t i = 0; i < results_.size(); i++) {
     autoware_new_planning_msgs::msg::EvaluationInfo eval_info;


### PR DESCRIPTION
With the current implementation, `best()` might return a `nullptr` which leads to memory access error when getting header information from `best()->header()`.
This PR fixes the issue, by using the clock time and hard coding the `frame_id`.