### PR TITLE
feat(trajectory_adaptor): remove duplicated point

### DIFF
--- a/autoware_trajectory_adaptor/package.xml
+++ b/autoware_trajectory_adaptor/package.xml
@@ -17,6 +17,7 @@
   <depend>autoware_new_planning_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_universe_utils</depend>
+  <depend>autoware_motion_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>visualization_msgs</depend>

--- a/autoware_trajectory_adaptor/src/node.cpp
+++ b/autoware_trajectory_adaptor/src/node.cpp
@@ -14,6 +14,8 @@
 
 #include "node.hpp"
 
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+
 namespace autoware::trajectory_selector::trajectory_adaptor
 {
 
@@ -51,9 +53,11 @@ void TrajectoryAdaptorNode::process(const InputMsgType::ConstSharedPtr msg)
     this->get_logger(), "best generator:" << best_generator(trajectory_itr->generator_id)
                                           << " score:" << trajectory_itr->score);
 
+  const auto traj_points = autoware::motion_utils::removeOverlapPoints(trajectory_itr->points);
   const auto trajectory = autoware_planning_msgs::build<OutputMsgType>()
                             .header(trajectory_itr->header)
-                            .points(trajectory_itr->points);
+                            .points(traj_points);
+
   pub_trajectory_->publish(trajectory);
 }
 


### PR DESCRIPTION
## Description
Current Autoware controller cannot handle trajectory with duplicated point inside.
This PR removes duplicated points before publishing the selected trajectory. 