### PR TITLE
feat: add current steering information

### DIFF
--- a/autoware_new_planning_launch/launch/selector.launch.xml
+++ b/autoware_new_planning_launch/launch/selector.launch.xml
@@ -61,6 +61,7 @@
       <remap from="~/input/lanelet2_map" to="/map/vector_map"/>
       <remap from="~/input/odometry" to="/localization/kinematic_state"/>
       <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
+      <remap from="~/input/steering" to="/vehicle/status/steering_status"/>
       <remap from="~/output/markers" to="/planning/trajectory_selector/ranker/markers"/>
     </composable_node>
 

--- a/autoware_offline_evaluation_tools/src/evaluation.cpp
+++ b/autoware_offline_evaluation_tools/src/evaluation.cpp
@@ -53,6 +53,8 @@ void BagEvaluator::setup(
   odometry_ = std::dynamic_pointer_cast<Buffer<Odometry>>(bag_data->buffers.at(TOPIC::ODOMETRY))
                 ->get(bag_data->timestamp);
 
+  steering_ = std::dynamic_pointer_cast<Buffer<SteeringReport>>(bag_data->buffers.at(TOPIC::STEERING))->get(bag_data->timestamp);
+
   objects_ = objects(bag_data, parameters_);
 
   preferred_lanes_ = preferred_lanes(bag_data, route_handler());
@@ -60,7 +62,7 @@ void BagEvaluator::setup(
   // add actual driving data
   {
     const auto core_data = std::make_shared<CoreData>(
-      ground_truth(bag_data, parameters_), previous_points, objects_, odometry_, preferred_lanes_,
+      ground_truth(bag_data, parameters_), previous_points, objects_, odometry_, steering_, preferred_lanes_,
       "ground_truth");
 
     add(core_data);
@@ -69,7 +71,7 @@ void BagEvaluator::setup(
   // data augmentation
   for (const auto & points : augment_data(bag_data, vehicle_info(), parameters_)) {
     const auto core_data = std::make_shared<CoreData>(
-      points, previous_points, objects_, odometry_, preferred_lanes_, "candidates");
+      points, previous_points, objects_, odometry_, steering_, preferred_lanes_, "candidates");
 
     add(core_data);
   }

--- a/autoware_offline_evaluation_tools/src/evaluation.hpp
+++ b/autoware_offline_evaluation_tools/src/evaluation.hpp
@@ -81,6 +81,8 @@ private:
 
   std::shared_ptr<Odometry> odometry_;
 
+  std::shared_ptr<SteeringReport> steering_;
+
   std::shared_ptr<PredictedObjects> objects_;
 
   std::shared_ptr<lanelet::ConstLanelets> preferred_lanes_;

--- a/autoware_trajectory_metrics/src/metrics.cpp
+++ b/autoware_trajectory_metrics/src/metrics.cpp
@@ -20,6 +20,8 @@
 
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 
+#include <rcl/subscription.h>
+
 namespace autoware::trajectory_selector::trajectory_metrics
 {
 
@@ -114,19 +116,13 @@ void TrajectoryDeviation::evaluate(const std::shared_ptr<DataInterface> & result
 
 void SteeringConsistency::evaluate(const std::shared_ptr<DataInterface> & result) const
 {
-  if (result->previous() == nullptr) return;
-
-  const auto ego_pose = result->odometry()->pose.pose;
-  const auto wheel_base = vehicle_info()->wheel_base_m;
-
-  const auto current = utils::steer_command(result->points(), ego_pose, wheel_base);
-  const auto previous = utils::steer_command(result->previous(), ego_pose, wheel_base);
+  const auto steering_angle = result->steering()->steering_tire_angle;
 
   std::vector<double> metric;
 
   metric.reserve(result->points()->size());
-  for (size_t i = 0; i < result->points()->size(); i++) {
-    metric.push_back(std::abs(current - previous));
+  for (const auto & point : *result->points()) {
+    metric.push_back(std::abs(point.front_wheel_angle_rad - steering_angle));
   }
 
   result->set_metric(index(), metric);

--- a/autoware_trajectory_ranker/src/node.cpp
+++ b/autoware_trajectory_ranker/src/node.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <limits>
+#include <memory>
 #include <string>
 
 namespace autoware::trajectory_selector::trajectory_ranker
@@ -85,6 +86,12 @@ auto TrajectoryRankerNode::score(const Trajectories::ConstSharedPtr msg)
   if (objects_ptr == nullptr) {
     return msg;
   }
+
+  const auto steering_ptr = std::const_pointer_cast<SteeringReport>(sub_steering_.takeData());
+  if(steering_ptr == nullptr) {
+    return msg;
+  }
+
   const auto preferred_lanes =
     std::make_shared<lanelet::ConstLanelets>(route_handler_->getPreferredLanelets());
 
@@ -101,7 +108,7 @@ auto TrajectoryRankerNode::score(const Trajectories::ConstSharedPtr msg)
 
     const auto core_data = std::make_shared<CoreData>(
       std::make_shared<TrajectoryPoints>(t.points), std::make_shared<TrajectoryPoints>(points),
-      previous_points_, objects_ptr, odometry_ptr, preferred_lanes, t.header, t.generator_id);
+      previous_points_, objects_ptr, odometry_ptr, steering_ptr, preferred_lanes, t.header, t.generator_id);
 
     evaluator_->add(core_data);
   }

--- a/autoware_trajectory_ranker/src/node.hpp
+++ b/autoware_trajectory_ranker/src/node.hpp
@@ -52,6 +52,8 @@ private:
   autoware::universe_utils::InterProcessPollingSubscriber<Odometry> sub_odometry_{
     this, "~/input/odometry"};
 
+  autoware::universe_utils::InterProcessPollingSubscriber<SteeringReport> sub_steering_{this,"~/input/steering"};
+
   rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_map_;
 
   rclcpp::Subscription<LaneletRoute>::SharedPtr sub_route_;

--- a/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/interface/data_interface.hpp
+++ b/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/interface/data_interface.hpp
@@ -86,7 +86,9 @@ public:
       return false;
     }
 
-    const auto condition = [&epsilon](const auto & p) { return p.longitudinal_velocity_mps >= epsilon; };
+    const auto condition = [&epsilon](const auto & p) {
+      return p.longitudinal_velocity_mps >= epsilon;
+    };
     return std::all_of(core_data_->points->begin(), core_data_->points->end(), condition);
   }
 
@@ -108,6 +110,8 @@ public:
   auto objects() const -> std::shared_ptr<PredictedObjects> { return core_data_->objects; }
 
   auto odometry() const -> std::shared_ptr<Odometry> { return core_data_->odometry; }
+
+  auto steering() const -> std::shared_ptr<SteeringReport> { return core_data_->steering; }
 
   auto preferred_lanes() const -> std::shared_ptr<lanelet::ConstLanelets>
   {

--- a/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/structs.hpp
+++ b/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/structs.hpp
@@ -47,12 +47,14 @@ struct CoreData
     const std::shared_ptr<TrajectoryPoints> & points,
     const std::shared_ptr<TrajectoryPoints> & previous_points,
     const std::shared_ptr<PredictedObjects> & objects, const std::shared_ptr<Odometry> & odometry,
+    const std::shared_ptr<SteeringReport> & steering,
     const std::shared_ptr<lanelet::ConstLanelets> & preferred_lanes, const std::string & tag)
   : original{points},
     points{points},
     previous_points{previous_points},
     objects{objects},
     odometry{odometry},
+    steering{steering},
     preferred_lanes{preferred_lanes},
     tag{tag}
   {
@@ -63,6 +65,7 @@ struct CoreData
     const std::shared_ptr<TrajectoryPoints> & points,
     const std::shared_ptr<TrajectoryPoints> & previous_points,
     const std::shared_ptr<PredictedObjects> & objects, const std::shared_ptr<Odometry> & odometry,
+    const std::shared_ptr<SteeringReport> & steering,
     const std::shared_ptr<lanelet::ConstLanelets> & preferred_lanes, const Header & header,
     const UUID & generator_id)
   : original{original},
@@ -70,6 +73,7 @@ struct CoreData
     previous_points{previous_points},
     objects{objects},
     odometry{odometry},
+    steering{steering},
     preferred_lanes{preferred_lanes},
     tag{"__anon"},
     header{header},
@@ -86,6 +90,8 @@ struct CoreData
   std::shared_ptr<PredictedObjects> objects;
 
   std::shared_ptr<Odometry> odometry;
+
+  std::shared_ptr<SteeringReport> steering;
 
   std::shared_ptr<lanelet::ConstLanelets> preferred_lanes;
 


### PR DESCRIPTION
## Description
Use current steering information instead of calculating the steering angle from `utils::steer_command`.