### PR TITLE
feat: add time keeper

### DIFF
--- a/autoware_feasible_trajectory_filter/src/node.cpp
+++ b/autoware_feasible_trajectory_filter/src/node.cpp
@@ -21,10 +21,17 @@ FeasibleTrajectoryFilterNode::FeasibleTrajectoryFilterNode(const rclcpp::NodeOpt
 : TrajectoryFilterInterface{"feasible_trajectory_filter_node", node_options},
   listener_{std::make_unique<feasible::ParamListener>(get_node_parameters_interface())}
 {
+  debug_processing_time_detail_pub_ =
+    create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
+      "~/debug/processing_time_detail_ms/feasible_trajectory_filter", 1);
+  time_keeper_ =
+    std::make_shared<autoware::universe_utils::TimeKeeper>(debug_processing_time_detail_pub_);
 }
 
 void FeasibleTrajectoryFilterNode::process(const Trajectories::ConstSharedPtr msg)
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   publish(msg);
 }
 

--- a/autoware_feasible_trajectory_filter/src/node.hpp
+++ b/autoware_feasible_trajectory_filter/src/node.hpp
@@ -15,8 +15,11 @@
 #ifndef NODE_HPP_
 #define NODE_HPP_
 
-#include "autoware_feasible_trajectory_filter_param.hpp"
 #include "autoware/trajectory_selector_common/interface/node_interface.hpp"
+#include "autoware_feasible_trajectory_filter_param.hpp"
+
+#include <autoware/universe_utils/system/time_keeper.hpp>
+
 #include <memory>
 
 namespace autoware::trajectory_selector::feasible_trajectory_filter
@@ -31,6 +34,10 @@ private:
   void process(const Trajectories::ConstSharedPtr msg) override;
 
   std::unique_ptr<feasible::ParamListener> listener_;
+
+  rclcpp::Publisher<autoware::universe_utils::ProcessingTimeDetail>::SharedPtr
+    debug_processing_time_detail_pub_;
+  mutable std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_{nullptr};
 };
 
 }  // namespace autoware::trajectory_selector::feasible_trajectory_filter

--- a/autoware_trajectory_adaptor/src/node.cpp
+++ b/autoware_trajectory_adaptor/src/node.cpp
@@ -26,10 +26,17 @@ TrajectoryAdaptorNode::TrajectoryAdaptorNode(const rclcpp::NodeOptions & node_op
     std::bind(&TrajectoryAdaptorNode::process, this, std::placeholders::_1))},
   pub_trajectory_{this->create_publisher<OutputMsgType>("~/output/trajectory", 1)}
 {
+  debug_processing_time_detail_pub_ =
+    create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
+      "~/debug/processing_time_detail_ms/trajectory_adaptor", 1);
+  time_keeper_ =
+    std::make_shared<autoware::universe_utils::TimeKeeper>(debug_processing_time_detail_pub_);
 }
 
 void TrajectoryAdaptorNode::process(const InputMsgType::ConstSharedPtr msg)
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   if (msg->trajectories.empty()) {
     return;
   }

--- a/autoware_trajectory_adaptor/src/node.hpp
+++ b/autoware_trajectory_adaptor/src/node.hpp
@@ -15,6 +15,7 @@
 #ifndef NODE_HPP_
 #define NODE_HPP_
 
+#include <autoware/universe_utils/system/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "autoware_new_planning_msgs/msg/trajectories.hpp"
@@ -37,6 +38,10 @@ private:
   rclcpp::Subscription<InputMsgType>::SharedPtr sub_trajectories_;
 
   rclcpp::Publisher<OutputMsgType>::SharedPtr pub_trajectory_;
+
+  rclcpp::Publisher<autoware::universe_utils::ProcessingTimeDetail>::SharedPtr
+    debug_processing_time_detail_pub_;
+  mutable std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_{nullptr};
 };
 
 }  // namespace autoware::trajectory_selector::trajectory_adaptor

--- a/autoware_trajectory_concatenator/src/node.hpp
+++ b/autoware_trajectory_concatenator/src/node.hpp
@@ -18,6 +18,7 @@
 #include "autoware_trajectory_concatenator_param.hpp"
 #include "structs.hpp"
 
+#include <autoware/universe_utils/system/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "autoware_new_planning_msgs/msg/trajectories.hpp"
@@ -59,6 +60,10 @@ private:
   std::map<std::string, Trajectories::ConstSharedPtr> buffer_;
 
   mutable std::mutex mutex_;
+
+  rclcpp::Publisher<autoware::universe_utils::ProcessingTimeDetail>::SharedPtr
+    debug_processing_time_detail_pub_;
+  mutable std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_{nullptr};
 };
 
 }  // namespace autoware::trajectory_selector::trajectory_concatenator

--- a/autoware_trajectory_ranker/src/node.cpp
+++ b/autoware_trajectory_ranker/src/node.cpp
@@ -40,7 +40,8 @@ TrajectoryRankerNode::TrajectoryRankerNode(const rclcpp::NodeOptions & node_opti
 : TrajectoryFilterInterface{"trajectory_ranker_node", node_options},
   pub_marker_{this->create_publisher<MarkerArray>("~/output/markers", 1)},
   pub_trajectories_debug_{this->create_publisher<TrajectoriesDebug>("~/output/score_debug", 1)},
-  pub_resampled_trajectories_{this->create_publisher<Trajectories>("~/output/resampled_trajectories", 1)},
+  pub_resampled_trajectories_{
+    this->create_publisher<Trajectories>("~/output/resampled_trajectories", 1)},
   listener_{std::make_unique<evaluation::ParamListener>(get_node_parameters_interface())},
   route_handler_{std::make_shared<RouteHandler>()},
   previous_points_{nullptr}
@@ -62,17 +63,28 @@ TrajectoryRankerNode::TrajectoryRankerNode(const rclcpp::NodeOptions & node_opti
   sub_route_ = create_subscription<LaneletRoute>(
     "~/input/route", rclcpp::QoS{1}.transient_local(),
     [this](const LaneletRoute::ConstSharedPtr msg) { route_handler_->setRoute(*msg); });
+
+  debug_processing_time_detail_pub_ =
+    create_publisher<autoware::universe_utils::ProcessingTimeDetail>(
+      "~/debug/processing_time_detail_ms/trajectory_ranker", 1);
+  time_keeper_ =
+    std::make_shared<autoware::universe_utils::TimeKeeper>(debug_processing_time_detail_pub_);
 }
 
 void TrajectoryRankerNode::process(const Trajectories::ConstSharedPtr msg)
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   publish(score(msg));
-  publish_resampled_trajectory(msg); //// TODO(go-sakayori): remove this function when the ranker is stable
+  publish_resampled_trajectory(
+    msg);  //// TODO(go-sakayori): remove this function when the ranker is stable
 }
 
 auto TrajectoryRankerNode::score(const Trajectories::ConstSharedPtr msg)
   -> Trajectories::ConstSharedPtr
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   if (!route_handler_->isHandlerReady()) {
     return msg;
   }
@@ -88,7 +100,7 @@ auto TrajectoryRankerNode::score(const Trajectories::ConstSharedPtr msg)
   }
 
   const auto steering_ptr = std::const_pointer_cast<SteeringReport>(sub_steering_.takeData());
-  if(steering_ptr == nullptr) {
+  if (steering_ptr == nullptr) {
     return msg;
   }
 
@@ -108,7 +120,8 @@ auto TrajectoryRankerNode::score(const Trajectories::ConstSharedPtr msg)
 
     const auto core_data = std::make_shared<CoreData>(
       std::make_shared<TrajectoryPoints>(t.points), std::make_shared<TrajectoryPoints>(points),
-      previous_points_, objects_ptr, odometry_ptr, steering_ptr, preferred_lanes, t.header, t.generator_id);
+      previous_points_, objects_ptr, odometry_ptr, steering_ptr, preferred_lanes, t.header,
+      t.generator_id);
 
     evaluator_->add(core_data);
   }
@@ -139,13 +152,21 @@ auto TrajectoryRankerNode::score(const Trajectories::ConstSharedPtr msg)
 
 void TrajectoryRankerNode::publish_resampled_trajectory(const Trajectories::ConstSharedPtr msg)
 {
+  autoware::universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+
   std::vector<Trajectory> trajectories;
 
-  for(const auto & result : evaluator_->results()) {
-    const auto resampled_trajectory = autoware_new_planning_msgs::build<Trajectory>().header(result->header()).generator_id(result->uuid()).points(*result->points()).score(result->total());
-    trajectories.push_back(resampled_trajectory);  
+  for (const auto & result : evaluator_->results()) {
+    const auto resampled_trajectory = autoware_new_planning_msgs::build<Trajectory>()
+                                        .header(result->header())
+                                        .generator_id(result->uuid())
+                                        .points(*result->points())
+                                        .score(result->total());
+    trajectories.push_back(resampled_trajectory);
   }
-  const auto resampled_trajectories = autoware_new_planning_msgs::build<Trajectories>().trajectories(trajectories).generator_info(msg->generator_info);
+  const auto resampled_trajectories = autoware_new_planning_msgs::build<Trajectories>()
+                                        .trajectories(trajectories)
+                                        .generator_info(msg->generator_info);
   pub_resampled_trajectories_->publish(resampled_trajectories);
 }
 

--- a/autoware_trajectory_ranker/src/node.hpp
+++ b/autoware_trajectory_ranker/src/node.hpp
@@ -20,6 +20,8 @@
 #include "autoware/universe_utils/ros/polling_subscriber.hpp"
 #include "autoware_trajectory_ranker_param.hpp"
 
+#include <autoware/universe_utils/system/time_keeper.hpp>
+
 #include "autoware_new_planning_msgs/msg/trajectories_debug.hpp"
 #include "autoware_new_planning_msgs/msg/trajectory.hpp"
 
@@ -41,7 +43,7 @@ private:
   void process(const Trajectories::ConstSharedPtr msg) override;
 
   auto score(const Trajectories::ConstSharedPtr msg) -> Trajectories::ConstSharedPtr;
-  
+
   void publish_resampled_trajectory(const Trajectories::ConstSharedPtr msg);
 
   auto parameters() const -> std::shared_ptr<EvaluatorParameters>;
@@ -52,7 +54,8 @@ private:
   autoware::universe_utils::InterProcessPollingSubscriber<Odometry> sub_odometry_{
     this, "~/input/odometry"};
 
-  autoware::universe_utils::InterProcessPollingSubscriber<SteeringReport> sub_steering_{this,"~/input/steering"};
+  autoware::universe_utils::InterProcessPollingSubscriber<SteeringReport> sub_steering_{
+    this, "~/input/steering"};
 
   rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_map_;
 
@@ -69,6 +72,10 @@ private:
   std::shared_ptr<RouteHandler> route_handler_;
 
   std::shared_ptr<TrajectoryPoints> previous_points_;
+
+  rclcpp::Publisher<autoware::universe_utils::ProcessingTimeDetail>::SharedPtr
+    debug_processing_time_detail_pub_;
+  mutable std::shared_ptr<autoware::universe_utils::TimeKeeper> time_keeper_{nullptr};
 };
 
 }  // namespace autoware::trajectory_selector::trajectory_ranker


### PR DESCRIPTION
## Description
Added time keeper to each node.

## How it was tested
Checked with the following command:
`ros2 run autoware_debug_tools processing_time_visualizer`

```
🌲 Total Processing Time Tree 🌲
100.00% on_trajectories: total 0.21 [ms], avg. 0.00 [ms], run count: 54

100.00% publish: total 0.75 [ms], avg. 0.03 [ms], run count: 30

⏰ Worst Case Execution Time ⏰
100.00% on_trajectories: total 0.04 [ms], avg. 0.04 [ms], run count: 1

100.00% publish: total 0.10 [ms], avg. 0.10 [ms], run count: 1
```

