### PR TITLE
fix(trajectory_selector_common): change method to get nearest index

### DIFF
--- a/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/utils.hpp
+++ b/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/utils.hpp
@@ -30,7 +30,7 @@ namespace autoware::trajectory_selector::utils
 
 auto sampling_with_time(
   const TrajectoryPoints & points, const size_t sample_num, const double resolution,
-  const size_t start_idx) -> TrajectoryPoints;
+  const std::optional<size_t> start_idx) -> TrajectoryPoints;
 
 auto find_nearest_timestamp(
   const TrajectoryPoints & points, const double target_timestamp,


### PR DESCRIPTION
## Description 
Ego segment index was used to resample the trajectories point. This PR changes to obtaining the nearest index instead, enabling to cope with trajectories that are behind the ego vehicle.