### PR TITLE
feat(feasible_trajectory_filter): exclude invalid trajectory

### DIFF
--- a/autoware_feasible_trajectory_filter/param/parameter_struct.yaml
+++ b/autoware_feasible_trajectory_filter/param/parameter_struct.yaml
@@ -4,3 +4,16 @@ feasible:
     default_value: 16.667
     description: Max velocity allowance.
     read_only: false
+
+  out_of_lane:
+    enable:
+      type: bool
+      default_value: true
+      description: Whether to check each trajectory stays within road lane
+      read_only: false
+
+    time:
+      type: double
+      default_value: 3.0
+      description: The time range to check
+      read_only: false


### PR DESCRIPTION
## Description
This PR excludes trajectories that has less than 2 points.
Also the out of lane condition is checked with a time range.