### PR TITLE
fix(trajectory_selector_common): check if resampled points are empty or not

### DIFF
--- a/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/interface/data_interface.hpp
+++ b/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/interface/data_interface.hpp
@@ -77,6 +77,7 @@ public:
 
   bool feasible() const
   {
+    if (core_data_->points->empty()) return false;
     constexpr double epsilon = -1e-06;
     const auto idx = autoware::motion_utils::findNearestIndex(
       *core_data_->points, core_data_->odometry->pose.pose.position);


### PR DESCRIPTION
## Description
`autoware::motion_utils::findNearestIndex`  throws an exception when the resampled points is empty.
This PR adds a if condition before calling the `autoware::motion_utils::findNearestIndex`.