### PR TITLE
feat(trajectory_adapter): add hazard signal information

### DIFF
--- a/autoware_new_planning_launch/launch/selector.launch.xml
+++ b/autoware_new_planning_launch/launch/selector.launch.xml
@@ -68,6 +68,7 @@
     <!-- select best trajectory -->
     <composable_node pkg="autoware_trajectory_adaptor" plugin="autoware::trajectory_selector::trajectory_adaptor::TrajectoryAdaptorNode" name="trajectory_adaptor_node" namespace="">
       <remap from="~/input/trajectories" to="/planning/trajectory_selector/scored/trajectories"/>
+      <remap from="~/output/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
       <remap from="~/output/trajectory" to="$(var control_component_input)"/>
       <remap from="~/output/markers" to="/planning/trajectory_selector/markers"/>
     </composable_node>

--- a/autoware_trajectory_adaptor/src/node.cpp
+++ b/autoware_trajectory_adaptor/src/node.cpp
@@ -15,7 +15,6 @@
 #include "node.hpp"
 
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
-#include <builtin_interfaces/msg/detail/duration__builder.hpp>
 
 namespace autoware::trajectory_selector::trajectory_adaptor
 {

--- a/autoware_trajectory_adaptor/src/node.hpp
+++ b/autoware_trajectory_adaptor/src/node.hpp
@@ -20,12 +20,14 @@
 
 #include "autoware_new_planning_msgs/msg/trajectories.hpp"
 #include "autoware_planning_msgs/msg/trajectory.hpp"
+#include <autoware_vehicle_msgs/msg/hazard_lights_command.hpp>
 
 namespace autoware::trajectory_selector::trajectory_adaptor
 {
 
 using InputMsgType = autoware_new_planning_msgs::msg::Trajectories;
 using OutputMsgType = autoware_planning_msgs::msg::Trajectory;
+using autoware_vehicle_msgs::msg::HazardLightsCommand;
 
 class TrajectoryAdaptorNode : public rclcpp::Node
 {
@@ -38,6 +40,9 @@ private:
   rclcpp::Subscription<InputMsgType>::SharedPtr sub_trajectories_;
 
   rclcpp::Publisher<OutputMsgType>::SharedPtr pub_trajectory_;
+  rclcpp::Publisher<HazardLightsCommand>::SharedPtr
+    hazard_signal_publisher_;  // To-do (go-sakayori): decide where to cope with turn indicator and
+                               // hazard signal
 
   rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
     debug_processing_time_detail_pub_;


### PR DESCRIPTION
## Description
Add hazard signal information for temporary usage.
This should be take into account with the turn indicator, whether it would be coped inside the trajectory adapter. 