### PR TITLE
feat(trajectory_concatenator) :concatenate selected trajectory

### DIFF
--- a/autoware_new_planning_launch/launch/selector.launch.xml
+++ b/autoware_new_planning_launch/launch/selector.launch.xml
@@ -28,7 +28,7 @@
     <composable_node pkg="autoware_trajectory_concatenator" plugin="autoware::trajectory_selector::trajectory_concatenator::TrajectoryConcatenatorNode" name="trajectory_concatenator" namespace="">
       <remap from="~/input/trajectories" to="$(var selector_component_input)"/>
       <remap from="~/input/odometry" to="/localization/kinematic_state"/>
-      <remap from="~/input/selected_trajectory" to="/planning/candidate/trajectories"/>
+      <remap from="~/input/selected_trajectory" to="$(var control_component_input)"/>
       <remap from="~/output/trajectories" to="/planning/trajectory_selector/concatenate/trajectories"/>
       <!-- composable node config -->
       <extra_arg name="use_intra_process_comms" value="false"/>

--- a/autoware_new_planning_launch/launch/selector.launch.xml
+++ b/autoware_new_planning_launch/launch/selector.launch.xml
@@ -27,6 +27,8 @@
     <!-- concatenate multiple topics -->
     <composable_node pkg="autoware_trajectory_concatenator" plugin="autoware::trajectory_selector::trajectory_concatenator::TrajectoryConcatenatorNode" name="trajectory_concatenator" namespace="">
       <remap from="~/input/trajectories" to="$(var selector_component_input)"/>
+      <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+      <remap from="~/input/selected_trajectory" to="/planning/candidate/trajectories"/>
       <remap from="~/output/trajectories" to="/planning/trajectory_selector/concatenate/trajectories"/>
       <!-- composable node config -->
       <extra_arg name="use_intra_process_comms" value="false"/>

--- a/autoware_trajectory_concatenator/CMakeLists.txt
+++ b/autoware_trajectory_concatenator/CMakeLists.txt
@@ -20,6 +20,10 @@ target_link_libraries(${PROJECT_NAME}
   ${PROJECT_NAME}_param
 )
 
+target_compile_options(${PROJECT_NAME} PUBLIC
+  -Wno-error=deprecated-declarations
+)
+
 rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "autoware::trajectory_selector::trajectory_concatenator::TrajectoryConcatenatorNode"
   EXECUTABLE ${PROJECT_NAME}_node

--- a/autoware_trajectory_concatenator/config/concatenator.param.yaml
+++ b/autoware_trajectory_concatenator/config/concatenator.param.yaml
@@ -1,3 +1,4 @@
 /**:
   ros__parameters:
     duration_time: 0.2 #[s]
+    endpoint_time_min: 10 #[s]

--- a/autoware_trajectory_concatenator/config/concatenator.param.yaml
+++ b/autoware_trajectory_concatenator/config/concatenator.param.yaml
@@ -1,4 +1,7 @@
 /**:
   ros__parameters:
     duration_time: 0.2 #[s]
-    endpoint_time_min: 10 #[s]
+
+    selected_trajectory:
+      use: false
+      endpoint_time_min: 10 #[s]

--- a/autoware_trajectory_concatenator/package.xml
+++ b/autoware_trajectory_concatenator/package.xml
@@ -16,7 +16,9 @@
 
   <depend>autoware_new_planning_msgs</depend>
   <depend>autoware_planning_msgs</depend>
+  <depend>autoware_trajectory_selector_common</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_motion_utils</depend>
   <depend>generate_parameter_library</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/autoware_trajectory_concatenator/param/parameter_struct.yaml
+++ b/autoware_trajectory_concatenator/param/parameter_struct.yaml
@@ -5,8 +5,15 @@ concatenator:
     description: Duration time to keep the trajectory (it will be deleted once exceeding this value).
     read_only: false
 
-  endpoint_time_min:
-    type: double
-    default_value: 10.0
-    description: The minimum value for time_from_start at the trajectory end point
-    read_only: false
+  selected_trajectory:
+    use:
+      type: bool
+      default_value: false
+      description: Whether to concatenate the previous selected trajectory (make a feedback loop or not)
+      read_only: false
+
+    endpoint_time_min:
+      type: double
+      default_value: 10.0
+      description: The minimum value for time_from_start at the trajectory end point
+      read_only: false

--- a/autoware_trajectory_concatenator/param/parameter_struct.yaml
+++ b/autoware_trajectory_concatenator/param/parameter_struct.yaml
@@ -4,3 +4,9 @@ concatenator:
     default_value: 0.2
     description: Duration time to keep the trajectory (it will be deleted once exceeding this value).
     read_only: false
+
+  endpoint_time_min:
+    type: double
+    default_value: 10.0
+    description: The minimum value for time_from_start at the trajectory end point
+    read_only: false

--- a/autoware_trajectory_concatenator/src/node.cpp
+++ b/autoware_trajectory_concatenator/src/node.cpp
@@ -87,7 +87,6 @@ void TrajectoryConcatenatorNode::on_selected_trajectory(
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  RCLCPP_INFO(get_logger(), "Received selected trajectory");
   const auto odometry_ptr = std::const_pointer_cast<Odometry>(sub_odometry_.take_data());
   if (odometry_ptr == nullptr) {
     return;
@@ -95,7 +94,6 @@ void TrajectoryConcatenatorNode::on_selected_trajectory(
 
   std::lock_guard<std::mutex> lock(mutex_);
 
-  RCLCPP_INFO(get_logger(), "Start extending selected trajectory");
   const auto uuid = autoware_utils::generate_default_uuid();
   const auto hex_uuid = autoware_utils::to_hex_string(uuid);
   const auto ego_seg_idx =

--- a/autoware_trajectory_concatenator/src/node.cpp
+++ b/autoware_trajectory_concatenator/src/node.cpp
@@ -32,6 +32,7 @@
 #include <autoware_planning_msgs/msg/detail/trajectory__struct.hpp>
 
 #include <chrono>
+#include <cmath>
 #include <functional>
 #include <memory>
 #include <string>
@@ -114,10 +115,8 @@ void TrajectoryConcatenatorNode::on_selected_trajectory(
   auto trajectory_time_duration =
     (rclcpp::Duration(end.sec, end.nanosec) - rclcpp::Duration(start.sec, start.nanosec)).seconds();
 
-  TrajectoryPoints trajectory_points;
-  trajectory_points.reserve(msg->points.size() - ego_seg_idx.value());
-  std::copy(
-    msg->points.begin() + ego_seg_idx.value(), msg->points.end(), trajectory_points.begin());
+  TrajectoryPoints trajectory_points(msg->points.begin() + ego_seg_idx.value(), msg->points.end());
+
   while (trajectory_time_duration < parameters()->min_end_time) {
     trajectory_points.push_back(
       autoware::trajectory_selector::utils::calc_extended_point(trajectory_points.back(), 0.1));

--- a/autoware_trajectory_concatenator/src/node.cpp
+++ b/autoware_trajectory_concatenator/src/node.cpp
@@ -91,6 +91,8 @@ void TrajectoryConcatenatorNode::on_selected_trajectory(
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
+  if (!parameters()->use_feedback) return;
+
   const auto odometry_ptr = std::const_pointer_cast<Odometry>(sub_odometry_.take_data());
   if (odometry_ptr == nullptr) {
     return;
@@ -204,7 +206,8 @@ auto TrajectoryConcatenatorNode::parameters() const -> std::shared_ptr<Concatena
   const auto parameters = std::make_shared<ConcatenatorParam>();
 
   parameters->duration_time = node_params.duration_time;
-  parameters->min_end_time = node_params.endpoint_time_min;
+  parameters->use_feedback = node_params.selected_trajectory.use;
+  parameters->min_end_time = node_params.selected_trajectory.endpoint_time_min;
 
   return parameters;
 }

--- a/autoware_trajectory_concatenator/src/node.hpp
+++ b/autoware_trajectory_concatenator/src/node.hpp
@@ -24,6 +24,7 @@
 #include <rclcpp/subscription.hpp>
 
 #include "autoware_new_planning_msgs/msg/trajectories.hpp"
+#include <autoware_planning_msgs/msg/detail/trajectory__struct.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
 #include <map>
@@ -48,7 +49,7 @@ public:
 private:
   void on_trajectories(const Trajectories::ConstSharedPtr msg);
 
-  void on_selected_trajectory(const Trajectory::ConstSharedPtr msg);
+  void on_selected_trajectory(const autoware_planning_msgs::msg::Trajectory::ConstSharedPtr msg);
 
   void publish();
 
@@ -58,7 +59,7 @@ private:
 
   rclcpp::Subscription<Trajectories>::SharedPtr subs_trajectories_;
 
-  rclcpp::Subscription<Trajectory>::SharedPtr sub_selected_trajectory_;
+  rclcpp::Subscription<autoware_planning_msgs::msg::Trajectory>::SharedPtr sub_selected_trajectory_;
 
   autoware_utils::InterProcessPollingSubscriber<Odometry> sub_odometry_{this, "~/input/odometry"};
 

--- a/autoware_trajectory_concatenator/src/node.hpp
+++ b/autoware_trajectory_concatenator/src/node.hpp
@@ -15,13 +15,16 @@
 #ifndef NODE_HPP_
 #define NODE_HPP_
 
-#include "autoware_trajectory_concatenator_param.hpp"
 #include "structs.hpp"
 
+#include <autoware_trajectory_concatenator_param.hpp>
+#include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_utils/system/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <rclcpp/subscription.hpp>
 
 #include "autoware_new_planning_msgs/msg/trajectories.hpp"
+#include <nav_msgs/msg/odometry.hpp>
 
 #include <map>
 #include <memory>
@@ -36,7 +39,7 @@ using namespace std::literals::chrono_literals;
 using autoware_new_planning_msgs::msg::Trajectories;
 using autoware_new_planning_msgs::msg::Trajectory;
 using autoware_new_planning_msgs::msg::TrajectoryGeneratorInfo;
-
+using nav_msgs::msg::Odometry;
 class TrajectoryConcatenatorNode : public rclcpp::Node
 {
 public:
@@ -45,6 +48,8 @@ public:
 private:
   void on_trajectories(const Trajectories::ConstSharedPtr msg);
 
+  void on_selected_trajectory(const Trajectory::ConstSharedPtr msg);
+
   void publish();
 
   auto parameters() const -> std::shared_ptr<ConcatenatorParam>;
@@ -52,6 +57,10 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
 
   rclcpp::Subscription<Trajectories>::SharedPtr subs_trajectories_;
+
+  rclcpp::Subscription<Trajectory>::SharedPtr sub_selected_trajectory_;
+
+  autoware_utils::InterProcessPollingSubscriber<Odometry> sub_odometry_{this, "~/input/odometry"};
 
   rclcpp::Publisher<Trajectories>::SharedPtr pub_trajectores_;
 

--- a/autoware_trajectory_concatenator/src/structs.hpp
+++ b/autoware_trajectory_concatenator/src/structs.hpp
@@ -20,6 +20,7 @@ namespace autoware::trajectory_selector::trajectory_concatenator
 struct ConcatenatorParam
 {
   double duration_time;
+  double min_end_time;
 };
 }  // namespace autoware::trajectory_selector::trajectory_concatenator
 

--- a/autoware_trajectory_concatenator/src/structs.hpp
+++ b/autoware_trajectory_concatenator/src/structs.hpp
@@ -20,6 +20,7 @@ namespace autoware::trajectory_selector::trajectory_concatenator
 struct ConcatenatorParam
 {
   double duration_time;
+  bool use_feedback;
   double min_end_time;
 };
 }  // namespace autoware::trajectory_selector::trajectory_concatenator

--- a/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/utils.hpp
+++ b/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/utils.hpp
@@ -24,7 +24,9 @@
 
 namespace autoware::trajectory_selector::utils
 {
-  auto sampling(
+TrajectoryPoint calc_extended_point(const TrajectoryPoint & end_point, const double extension_time);
+
+auto sampling(
   const TrajectoryPoints & points, const Pose & p_ego, const size_t sample_num,
   const double time_resolution) -> TrajectoryPoints;
 

--- a/autoware_trajectory_selector_common/src/utils.cpp
+++ b/autoware_trajectory_selector_common/src/utils.cpp
@@ -17,15 +17,27 @@
 #include "autoware/interpolation/linear_interpolation.hpp"
 #include "autoware/motion_utils/trajectory/interpolation.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
+#include "autoware/trajectory_selector_common/type_alias.hpp"
 #include "autoware_utils/geometry/boost_polygon_utils.hpp"
 
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
 #include <magic_enum.hpp>
 #include <rclcpp/duration.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/utils.hpp>
+
+#include <autoware_planning_msgs/msg/detail/lanelet_route__builder.hpp>
+#include <autoware_planning_msgs/msg/detail/trajectory_point__struct.hpp>
+#include <geometry_msgs/msg/detail/point__struct.hpp>
+#include <geometry_msgs/msg/detail/pose__builder.hpp>
+#include <geometry_msgs/msg/detail/pose__struct.hpp>
+#include <geometry_msgs/msg/detail/twist__struct.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <boost/geometry/algorithms/disjoint.hpp>
 
+#include <cmath>
 #include <optional>
 #include <vector>
 
@@ -170,11 +182,45 @@ tf2::Vector3 get_velocity_in_world_coordinate(const TrajectoryPoint & point)
   return from_msg(v_world) - from_msg(pose.position);
 }
 
+TrajectoryPoint calc_extended_point(const TrajectoryPoint & end_point, const double extension_time)
+{
+  const auto new_yaw =
+    tf2::getYaw(end_point.pose.orientation) + end_point.heading_rate_rps * extension_time;
+  const auto new_time =
+    rclcpp::Duration(end_point.time_from_start) + rclcpp::Duration::from_seconds(extension_time);
+
+  const auto world_coordinate_velocity = get_velocity_in_world_coordinate(end_point);
+  const auto new_point =
+    geometry_msgs::build<Point>()
+      .x(end_point.pose.position.x + world_coordinate_velocity.x() * extension_time)
+      .y(end_point.pose.position.y + world_coordinate_velocity.y() * extension_time)
+      .z(end_point.pose.position.z);
+
+  tf2::Quaternion new_quaternion;
+  new_quaternion.setRPY(0.0, 0.0, new_yaw);
+
+  const auto new_pose =
+    geometry_msgs::build<Pose>().position(new_point).orientation(tf2::toMsg(new_quaternion));
+  const auto new_trajectory_point =
+    autoware_planning_msgs::build<TrajectoryPoint>()
+      .time_from_start(new_time)
+      .pose(new_pose)
+      .longitudinal_velocity_mps(
+        end_point.longitudinal_velocity_mps + end_point.acceleration_mps2 * extension_time)
+      .lateral_velocity_mps(end_point.lateral_velocity_mps)
+      .acceleration_mps2(end_point.acceleration_mps2)
+      .heading_rate_rps(end_point.heading_rate_rps)
+      .front_wheel_angle_rad(end_point.front_wheel_angle_rad)
+      .rear_wheel_angle_rad(end_point.rear_wheel_angle_rad);
+
+  return new_trajectory_point;
+}
+
 auto sampling(
   const TrajectoryPoints & points, const Pose & p_ego, const size_t sample_num,
   const double resolution) -> TrajectoryPoints
 {
-  const auto ego_seg_idx = autoware::motion_utils::findNearestIndex(points,p_ego, 10.0,M_PI_2);
+  const auto ego_seg_idx = autoware::motion_utils::findNearestIndex(points, p_ego, 10.0, M_PI_2);
 
   std::vector<double> timestamps;
   for (const auto & point : points) {
@@ -188,7 +234,7 @@ auto sampling(
 
   TrajectoryPoints output;
   FrenetPoint vehicle_pose_frenet;
-  if(ego_seg_idx.has_value()) {
+  if (ego_seg_idx.has_value()) {
     vehicle_pose_frenet = convertToFrenetPoint(points, p_ego.position, ego_seg_idx.value());
   }
 
@@ -221,7 +267,8 @@ auto sampling_with_time(
     return output;
   }
 
-  const double start_time = rclcpp::Duration(points.at(start_idx.value()).time_from_start).seconds();
+  const double start_time =
+    rclcpp::Duration(points.at(start_idx.value()).time_from_start).seconds();
 
   for (size_t i = 0; i < sample_num; i++) {
     const auto elapsed_time = static_cast<double>(i) * resolution + start_time;


### PR DESCRIPTION
## Description
Add a feedback loop for the selected trajectory.
The loop can be turned on/off by parameters.
It might be better to implement this function in another node, and would need further consideration.

## How it was tested
Checked that the concatenated trajectory size is 7(6 output from MTR and 1 from the selected trajectory)
![image](https://github.com/user-attachments/assets/3fd66726-73e2-4341-ba00-918cb2d60657)
