### PR TITLE
feat(feasible_trajectory_filter): check path origin

### DIFF
--- a/autoware_feasible_trajectory_filter/src/node.hpp
+++ b/autoware_feasible_trajectory_filter/src/node.hpp
@@ -18,6 +18,7 @@
 #include "autoware/trajectory_selector_common/interface/node_interface.hpp"
 #include "autoware_feasible_trajectory_filter_param.hpp"
 
+#include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_utils/system/time_keeper.hpp>
 
 #include <memory>
@@ -35,9 +36,11 @@ private:
 
   void map_callback(const LaneletMapBin::ConstSharedPtr msg);
 
-  auto check_feasibility(const Trajectories::ConstSharedPtr msg) -> Trajectories::ConstSharedPtr;
+  Trajectories::ConstSharedPtr check_feasibility(const Trajectories::ConstSharedPtr msg);
 
-  auto out_of_lane(const autoware_new_planning_msgs::msg::Trajectory & trajectory) -> bool;
+  bool check_trajectory_origin(const autoware_new_planning_msgs::msg::Trajectory & trajectory);
+
+  bool out_of_lane(const autoware_new_planning_msgs::msg::Trajectory & trajectory);
 
   std::unique_ptr<feasible::ParamListener> listener_;
 
@@ -46,6 +49,7 @@ private:
   mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
 
   rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_map_;
+  autoware_utils::InterProcessPollingSubscriber<Odometry> sub_odometry_{this, "~/input/odometry"};
 
   std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr_;
   std::shared_ptr<lanelet::routing::RoutingGraph> routing_graph_ptr_;

--- a/autoware_offline_evaluation_tools/src/evaluation.cpp
+++ b/autoware_offline_evaluation_tools/src/evaluation.cpp
@@ -50,9 +50,6 @@ void BagEvaluator::setup(
   tf_ = std::dynamic_pointer_cast<Buffer<TFMessage>>(bag_data->buffers.at(TOPIC::TF))
           ->get(bag_data->timestamp);
 
-  odometry_ = std::dynamic_pointer_cast<Buffer<Odometry>>(bag_data->buffers.at(TOPIC::ODOMETRY))
-                ->get(bag_data->timestamp);
-
   steering_ =
     std::dynamic_pointer_cast<Buffer<SteeringReport>>(bag_data->buffers.at(TOPIC::STEERING))
       ->get(bag_data->timestamp);
@@ -64,7 +61,7 @@ void BagEvaluator::setup(
   // add actual driving data
   {
     const auto core_data = std::make_shared<CoreData>(
-      ground_truth(bag_data, parameters_), previous_points, objects_, odometry_, preferred_lanes_,
+      ground_truth(bag_data, parameters_), previous_points, objects_, preferred_lanes_,
       "ground_truth");
 
     add(core_data);
@@ -72,8 +69,8 @@ void BagEvaluator::setup(
 
   // data augmentation
   for (const auto & points : augment_data(bag_data, vehicle_info(), parameters_)) {
-    const auto core_data = std::make_shared<CoreData>(
-      points, previous_points, objects_, odometry_, preferred_lanes_, "candidates");
+    const auto core_data =
+      std::make_shared<CoreData>(points, previous_points, objects_, preferred_lanes_, "candidates");
 
     add(core_data);
   }

--- a/autoware_trajectory_ranker/src/node.cpp
+++ b/autoware_trajectory_ranker/src/node.cpp
@@ -114,7 +114,7 @@ auto TrajectoryRankerNode::score(const Trajectories::ConstSharedPtr msg)
 
     const auto core_data = std::make_shared<CoreData>(
       std::make_shared<TrajectoryPoints>(t.points), std::make_shared<TrajectoryPoints>(points),
-      previous_points_, objects_ptr, odometry_ptr, preferred_lanes, t.header, t.generator_id);
+      previous_points_, objects_ptr, preferred_lanes, t.header, t.generator_id);
 
     evaluator_->add(core_data);
   }

--- a/autoware_trajectory_ranker/src/node.hpp
+++ b/autoware_trajectory_ranker/src/node.hpp
@@ -72,6 +72,8 @@ private:
   rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
     debug_processing_time_detail_pub_;
   mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
+
+  friend class TestTrajectoryRanker;
 };
 
 }  // namespace autoware::trajectory_selector::trajectory_ranker

--- a/autoware_trajectory_ranker/src/node.hpp
+++ b/autoware_trajectory_ranker/src/node.hpp
@@ -72,8 +72,6 @@ private:
   rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
     debug_processing_time_detail_pub_;
   mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
-
-  friend class TestTrajectoryRanker;
 };
 
 }  // namespace autoware::trajectory_selector::trajectory_ranker

--- a/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/interface/data_interface.hpp
+++ b/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/interface/data_interface.hpp
@@ -79,13 +79,6 @@ public:
   {
     if (core_data_->points->empty()) return false;
     constexpr double epsilon = -1e-06;
-    const auto idx = autoware::motion_utils::findNearestIndex(
-      *core_data_->points, core_data_->odometry->pose.pose.position);
-    const auto & p1 = core_data_->points->at(idx).pose.position;
-    const auto & p2 = core_data_->odometry->pose.pose.position;
-    if (autoware_utils::calc_squared_distance2d(p1, p2) > 10.0) {
-      return false;
-    }
 
     const auto condition = [&epsilon](const auto & p) {
       return p.longitudinal_velocity_mps >= epsilon;
@@ -109,8 +102,6 @@ public:
   auto original() const -> std::shared_ptr<TrajectoryPoints> { return core_data_->original; }
 
   auto objects() const -> std::shared_ptr<PredictedObjects> { return core_data_->objects; }
-
-  auto odometry() const -> std::shared_ptr<Odometry> { return core_data_->odometry; }
 
   auto steering() const -> std::shared_ptr<SteeringReport> { return core_data_->steering; }
 

--- a/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/structs.hpp
+++ b/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/structs.hpp
@@ -48,13 +48,12 @@ struct CoreData
   CoreData(
     const std::shared_ptr<TrajectoryPoints> & points,
     const std::shared_ptr<TrajectoryPoints> & previous_points,
-    const std::shared_ptr<PredictedObjects> & objects, const std::shared_ptr<Odometry> & odometry,
+    const std::shared_ptr<PredictedObjects> & objects,
     const std::shared_ptr<lanelet::ConstLanelets> & preferred_lanes, const std::string & tag)
   : original{points},
     points{points},
     previous_points{previous_points},
     objects{objects},
-    odometry{odometry},
     preferred_lanes{preferred_lanes},
     tag{tag}
   {
@@ -64,14 +63,13 @@ struct CoreData
     const std::shared_ptr<TrajectoryPoints> & original,
     const std::shared_ptr<TrajectoryPoints> & points,
     const std::shared_ptr<TrajectoryPoints> & previous_points,
-    const std::shared_ptr<PredictedObjects> & objects, const std::shared_ptr<Odometry> & odometry,
+    const std::shared_ptr<PredictedObjects> & objects,
     const std::shared_ptr<lanelet::ConstLanelets> & preferred_lanes, const Header & header,
     const UUID & generator_id)
   : original{original},
     points{points},
     previous_points{previous_points},
     objects{objects},
-    odometry{odometry},
     preferred_lanes{preferred_lanes},
     tag{"__anon"},
     header{header},
@@ -86,8 +84,6 @@ struct CoreData
   std::shared_ptr<TrajectoryPoints> previous_points;
 
   std::shared_ptr<PredictedObjects> objects;
-
-  std::shared_ptr<Odometry> odometry;
 
   std::shared_ptr<SteeringReport> steering;
 


### PR DESCRIPTION
## Description
Eliminate trajectories whose origin is a certain distance away from the ego vehicle's position.

## How it was tested
Was able to drive in PSim