### PR TITLE
feat(feasible_trajectory_filter): check path off tracking instead of only checking the origin

### DIFF
--- a/autoware_feasible_trajectory_filter/package.xml
+++ b/autoware_feasible_trajectory_filter/package.xml
@@ -16,6 +16,7 @@
 
   <depend>autoware_trajectory_selector_common</depend>
   <depend>generate_parameter_library</depend>
+  <depend>autoware_motion_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 

--- a/autoware_feasible_trajectory_filter/src/node.hpp
+++ b/autoware_feasible_trajectory_filter/src/node.hpp
@@ -38,7 +38,9 @@ private:
 
   Trajectories::ConstSharedPtr check_feasibility(const Trajectories::ConstSharedPtr msg);
 
-  bool check_trajectory_origin(const autoware_new_planning_msgs::msg::Trajectory & trajectory);
+  bool is_trajectory_offtrack(
+    const autoware_new_planning_msgs::msg::Trajectory & trajectory,
+    const geometry_msgs::msg::Point & ego_position);
 
   bool out_of_lane(const autoware_new_planning_msgs::msg::Trajectory & trajectory);
 

--- a/autoware_new_planning_launch/launch/selector.launch.xml
+++ b/autoware_new_planning_launch/launch/selector.launch.xml
@@ -43,6 +43,7 @@
     >
       <remap from="~/input/trajectories" to="/planning/trajectory_selector/concatenate/trajectories"/>
       <remap from="~/input/lanelet2_map" to="/map/vector_map"/>
+      <remap from="~/input/odometry" to="/localization/kinematic_state"/>
       <remap from="~/output/trajectories" to="/planning/trajectory_selector/feasible/trajectories"/>
     </composable_node>
 


### PR DESCRIPTION
## Description
Check for trajectory start position was introduced in PR: https://github.com/tier4/new_planning_framework/pull/90.
This would be suitable to a lot of E2E model based generator.
However some generators would generate trajectories with some margin behind the ego vehicle. (ex. Autoware behavior path planner)
Thus, the nearest point to the ego vehicle is checked instead. If the nearest point is certain distance away from the ego vehicle the candidate trajectory is eliminated.

## How it was tested
Moved the ego vehicle suddenly in PSim and checked that the output becomes 0, even though there are multiple candidates as inputs.
[Screencast from 2025年04月01日 16時39分51秒.webm](https://github.com/user-attachments/assets/acd11f91-bea2-4209-af14-6dc3ee3a69a0)
