### PR TITLE
feat(trajectory_metrics, selector_common): modify normalize method

### DIFF
--- a/autoware_trajectory_metrics/src/metrics.cpp
+++ b/autoware_trajectory_metrics/src/metrics.cpp
@@ -40,7 +40,7 @@ void LateralAcceleration::evaluate(
     const auto lateral_acc = (result->points()->at(i + 1).lateral_velocity_mps -
                               result->points()->at(i).lateral_velocity_mps) /
                              time_resolution;
-    metric.push_back(std::min(max_value, std::abs(lateral_acc)));
+    metric.push_back(std::min(1.0, std::abs(lateral_acc) / max_value));
   }
   metric.push_back(metric.back());
 
@@ -69,7 +69,7 @@ void LongitudinalJerk::evaluate(
   metric.reserve(result->points()->size());
   for (size_t i = 0; i < acceleration.size() - 1; i++) {
     const auto jerk = (acceleration.at(i + 1) - acceleration.at(i)) / time_resolution;
-    metric.push_back(std::min(max_value, std::abs(jerk)));
+    metric.push_back(std::min(1.0, std::abs(jerk) / max_value));
   }
   metric.push_back(metric.back());
 
@@ -84,7 +84,7 @@ void TimeToCollision::evaluate(
   metric.reserve(result->points()->size());
   for (size_t i = 0; i < result->points()->size(); i++) {
     metric.push_back(
-      std::min(max_value, utils::time_to_collision(result->points(), result->objects(), i)));
+      std::min(1.0, utils::time_to_collision(result->points(), result->objects(), i) / max_value));
   }
 
   result->set_metric(index(), metric);
@@ -97,8 +97,8 @@ void TravelDistance::evaluate(
 
   metric.reserve(result->points()->size());
   for (size_t i = 0; i < result->points()->size(); i++) {
-    metric.push_back(
-      std::min(max_value, autoware::motion_utils::calcSignedArcLength(*result->points(), 0L, i)));
+    metric.push_back(std::min(
+      1.0, autoware::motion_utils::calcSignedArcLength(*result->points(), 0L, i) / max_value));
   }
 
   result->set_metric(index(), metric);
@@ -113,7 +113,7 @@ void LateralDeviation::evaluate(
   for (size_t i = 0; i < result->points()->size(); i++) {
     const auto arc_coordinates = lanelet::utils::getArcCoordinates(
       *result->preferred_lanes(), autoware_utils::get_pose(result->points()->at(i)));
-    metric.push_back(std::min(max_value, std::abs(arc_coordinates.distance)));
+    metric.push_back(std::min(1.0, std::abs(arc_coordinates.distance) / max_value));
   }
 
   result->set_metric(index(), metric);
@@ -151,7 +151,7 @@ void SteeringConsistency::evaluate(
     const auto current = utils::steer_command(result->points(), point.pose, wheel_base);
     const auto previous = utils::steer_command(result->previous(), point.pose, wheel_base);
 
-    metric.push_back(std::min(max_value, std::abs(current - previous)));
+    metric.push_back(std::min(1.0, std::abs(current - previous) / max_value));
   }
 
   result->set_metric(index(), metric);

--- a/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/evaluation.hpp
+++ b/autoware_trajectory_selector_common/include/autoware/trajectory_selector_common/evaluation.hpp
@@ -79,7 +79,7 @@ protected:
 
   void compress(const std::vector<std::vector<double>> & weight);
 
-  void normalize();
+  void normalize(const std::vector<std::vector<double>> & weight);
 
   void weighting(const std::vector<double> & weight);
 

--- a/autoware_trajectory_selector_common/src/evaluation.cpp
+++ b/autoware_trajectory_selector_common/src/evaluation.cpp
@@ -82,7 +82,7 @@ void Evaluator::evaluate(const std::vector<double> & max_value)
   }
 }
 
-void Evaluator::normalize()
+void Evaluator::normalize(const std::vector<std::vector<double>> & weight)
 {
   if (results_.empty()) return;
 
@@ -94,13 +94,9 @@ void Evaluator::normalize()
     return;
   }
 
-  const auto range = [this](const size_t index) {
-    double min = std::numeric_limits<double>::max();
-    double max = std::numeric_limits<double>::lowest();
-    for (const auto & result : results_) {
-      min = std::min(min, result->score(index));
-      max = std::max(max, result->score(index));
-    }
+  const auto range = [weight](const size_t index) {
+    double min = 0.0;
+    double max = std::reduce(weight.at(index).begin(), weight.at(index).end());
     return std::make_pair(min, max);
   };
 
@@ -160,7 +156,7 @@ auto Evaluator::best(
 
   compress(parameters->time_decay_weight);
 
-  normalize();
+  normalize(parameters->time_decay_weight);
 
   weighting(parameters->score_weight);
 


### PR DESCRIPTION
## Description
Change normalization method.

- Before multiplying the `time_decay_weight`, each metric value is normalized. The denominator for normalization is defined as a parameter
- Before multiplying the `score_weight`, each metric sum is normalized. The denominator for normalization is defined as the sum of the `time_decay_weight`