### PR TITLE
fix dependency issue for uuid

### DIFF
--- a/autoware_new_planning_msgs_converter/package.xml
+++ b/autoware_new_planning_msgs_converter/package.xml
@@ -20,7 +20,7 @@
   <depend>autoware_new_planning_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_topic_converter</depend>
-  <depend>autoware_utils</depend>
+  <depend>autoware_utils_uuid</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 

--- a/autoware_new_planning_msgs_converter/package.xml
+++ b/autoware_new_planning_msgs_converter/package.xml
@@ -20,7 +20,7 @@
   <depend>autoware_new_planning_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_planning_topic_converter</depend>
-  <depend>autoware_utils_uuid</depend>
+  <depend>autoware_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 

--- a/autoware_new_planning_msgs_converter/src/trajectory_to_trajectories.hpp
+++ b/autoware_new_planning_msgs_converter/src/trajectory_to_trajectories.hpp
@@ -18,7 +18,7 @@
 #include "autoware/planning_topic_converter/converter_base.hpp"
 #include "rclcpp/rclcpp.hpp"
 
-#include <autoware_utils/ros/uuid_helper.hpp>
+#include <autoware_utils_uuid/uuid_helper.hpp>
 
 #include "autoware_new_planning_msgs/msg/trajectories.hpp"
 #include "autoware_new_planning_msgs/msg/trajectory.hpp"


### PR DESCRIPTION
Due to changes in autoware, the dependency name for uuid utilities is different