### PR TITLE
use boundary departure checker to speed up lanelet queries

### DIFF
--- a/autoware_valid_trajectory_filter/package.xml
+++ b/autoware_valid_trajectory_filter/package.xml
@@ -16,6 +16,7 @@
 
   <depend>autoware_traffic_light_utils</depend>
   <depend>autoware_trajectory_selector_common</depend>
+  <depend>autoware_behavior_path_planner_common</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/autoware_valid_trajectory_filter/package.xml
+++ b/autoware_valid_trajectory_filter/package.xml
@@ -17,6 +17,7 @@
   <depend>autoware_traffic_light_utils</depend>
   <depend>autoware_trajectory_selector_common</depend>
   <depend>autoware_behavior_path_planner_common</depend>
+  <depend>autoware_utils_debug</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/autoware_valid_trajectory_filter/src/node.cpp
+++ b/autoware_valid_trajectory_filter/src/node.cpp
@@ -121,11 +121,8 @@ Trajectories::ConstSharedPtr ValidTrajectoryFilterNode::traffic_light_check(
     std::remove_if(trajectories.begin(), trajectories.end(), [&](const auto & trajectory) {
       // TODO: this query is slow, consider using other methods similar to
       // BoundaryDepartureChecker::getFusedLaneletPolygonForPath?
-      time_keeper_->start_track("get_lanelets_from_trajectory");
       const auto lanes = get_lanelets_from_trajectory(trajectory.points);
-      time_keeper_->end_track("get_lanelets_from_trajectory");
 
-      time_keeper_->start_track("loop");
       for (const auto & lane : lanes) {
         for (const auto & element : lane.template regulatoryElementsAs<lanelet::TrafficLight>()) {
           if (traffic_light_id_map_.count(element->id()) == 0) continue;
@@ -136,8 +133,6 @@ Trajectories::ConstSharedPtr ValidTrajectoryFilterNode::traffic_light_check(
           }
         }
       }
-      time_keeper_->end_track("loop");
-
       return false;
     });
   trajectories.erase(itr, trajectories.end());

--- a/autoware_valid_trajectory_filter/src/node.cpp
+++ b/autoware_valid_trajectory_filter/src/node.cpp
@@ -21,6 +21,7 @@
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <rclcpp/logging.hpp>
 
+#include <autoware_internal_planning_msgs/msg/detail/path_point_with_lane_id__struct.hpp>
 #include <autoware_new_planning_msgs/msg/detail/trajectories__struct.hpp>
 
 #include <lanelet2_core/Forward.h>
@@ -33,31 +34,74 @@
 
 namespace autoware::trajectory_selector::valid_trajectory_filter
 {
+using autoware_internal_planning_msgs::msg::PathPointWithLaneId;
+using autoware_internal_planning_msgs::msg::PathWithLaneId;
 
 ValidTrajectoryFilterNode::ValidTrajectoryFilterNode(const rclcpp::NodeOptions & node_options)
-: TrajectoryFilterInterface{"trajectory_ranker_node", node_options}
+: TrajectoryFilterInterface{"trajectory_ranker_node", node_options},
+  vehicle_info_{autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo()}
 {
+  debug_processing_time_detail_pub_ = this->create_publisher<autoware_utils::ProcessingTimeDetail>(
+    "~/debug/processing_time_detail_ms", 1);
+  time_keeper_ = std::make_shared<autoware_utils::TimeKeeper>(debug_processing_time_detail_pub_);
   sub_map_ = create_subscription<LaneletMapBin>(
     "~/input/lanelet2_map", rclcpp::QoS{1}.transient_local(),
     std::bind(&ValidTrajectoryFilterNode::map_callback, this, std::placeholders::_1));
+
+  autoware::boundary_departure_checker::Param boundary_departure_checker_params;
+  boundary_departure_checker_ =
+    std::make_shared<autoware::boundary_departure_checker::BoundaryDepartureChecker>(
+      boundary_departure_checker_params, vehicle_info_, time_keeper_);
 }
 
 void ValidTrajectoryFilterNode::process(const Trajectories::ConstSharedPtr msg)
 {
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   const auto trajectories = traffic_light_check(msg);
   publish(trajectories);
 }
 
 void ValidTrajectoryFilterNode::map_callback(const LaneletMapBin::ConstSharedPtr msg)
 {
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   lanelet_map_ptr_ = std::make_shared<lanelet::LaneletMap>();
   lanelet::utils::conversion::fromBinMsg(
     *msg, lanelet_map_ptr_, &traffic_rules_ptr_, &routing_graph_ptr_);
 }
 
+lanelet::ConstLanelets ValidTrajectoryFilterNode::get_lanelets_from_trajectory(
+  const TrajectoryPoints & trajectory_points) const
+{
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
+  lanelet::ConstLanelets lanes;
+  PathWithLaneId path;
+  path.points.reserve(trajectory_points.size());
+  for (const auto & point : trajectory_points) {
+    PathPointWithLaneId path_point;
+    path_point.point.pose = point.pose;
+    path_point.point.longitudinal_velocity_mps = point.longitudinal_velocity_mps;
+    path_point.point.lateral_velocity_mps = point.lateral_velocity_mps;
+    path_point.point.heading_rate_rps = point.heading_rate_rps;
+    path.points.push_back(path_point);
+  }
+  const auto lanelet_distance_pair =
+    boundary_departure_checker_->getLaneletsFromPath(lanelet_map_ptr_, path);
+  if (lanelet_distance_pair.empty()) {
+    RCLCPP_WARN(get_logger(), "No lanelets found in the map");
+    return lanes;
+  }
+
+  for (const auto & lanelet_distance : lanelet_distance_pair) {
+    const auto & lanelet = lanelet_distance.second;
+    lanes.push_back(lanelet);
+  }
+  return lanes;
+}
+
 Trajectories::ConstSharedPtr ValidTrajectoryFilterNode::traffic_light_check(
   const Trajectories::ConstSharedPtr msg)
 {
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   auto trajectories = msg->trajectories;
   const auto traffic_signal_msg = traffic_signals_subscriber_.take_data();
 
@@ -72,13 +116,16 @@ Trajectories::ConstSharedPtr ValidTrajectoryFilterNode::traffic_light_check(
   }
 
   if (!lanelet_map_ptr_) return std::make_shared<Trajectories>();
-  const lanelet::ConstLanelets lanelets(
-    lanelet_map_ptr_->laneletLayer.begin(), lanelet_map_ptr_->laneletLayer.end());
 
-  const auto itr = std::remove_if(
-    trajectories.begin(), trajectories.end(), [this, lanelets](const auto & trajectory) {
-      const auto lanes = utils::get_lanes_from_trajectory(trajectory.points, lanelets);
+  const auto itr =
+    std::remove_if(trajectories.begin(), trajectories.end(), [&](const auto & trajectory) {
+      // TODO: this query is slow, consider using other methods similar to
+      // BoundaryDepartureChecker::getFusedLaneletPolygonForPath?
+      time_keeper_->start_track("get_lanelets_from_trajectory");
+      const auto lanes = get_lanelets_from_trajectory(trajectory.points);
+      time_keeper_->end_track("get_lanelets_from_trajectory");
 
+      time_keeper_->start_track("loop");
       for (const auto & lane : lanes) {
         for (const auto & element : lane.template regulatoryElementsAs<lanelet::TrafficLight>()) {
           if (traffic_light_id_map_.count(element->id()) == 0) continue;
@@ -89,6 +136,7 @@ Trajectories::ConstSharedPtr ValidTrajectoryFilterNode::traffic_light_check(
           }
         }
       }
+      time_keeper_->end_track("loop");
 
       return false;
     });
@@ -104,6 +152,7 @@ Trajectories::ConstSharedPtr ValidTrajectoryFilterNode::traffic_light_check(
 Trajectories::ConstSharedPtr ValidTrajectoryFilterNode::stop_line_check(
   const Trajectories::ConstSharedPtr msg)
 {
+  autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
   auto trajectories = msg->trajectories;
   if (!lanelet_map_ptr_) return std::make_shared<Trajectories>();
   const lanelet::ConstLanelets lanelets(

--- a/autoware_valid_trajectory_filter/src/node.hpp
+++ b/autoware_valid_trajectory_filter/src/node.hpp
@@ -19,7 +19,7 @@
 
 #include <autoware/boundary_departure_checker/boundary_departure_checker.hpp>
 #include <autoware/trajectory_selector_common/type_alias.hpp>
-#include <autoware_utils/system/time_keeper.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/subscription.hpp>
 

--- a/autoware_valid_trajectory_filter/src/node.hpp
+++ b/autoware_valid_trajectory_filter/src/node.hpp
@@ -70,11 +70,11 @@ private:
   std::map<int64_t, TrafficSignalStamped> traffic_light_id_map_;
 
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
-  rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
+  rclcpp::Publisher<autoware_utils_debug::ProcessingTimeDetail>::SharedPtr
     debug_processing_time_detail_pub_;
   std::shared_ptr<BoundaryDepartureChecker> boundary_departure_checker_;
 
-  mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
+  mutable std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_{nullptr};
 };
 
 }  // namespace autoware::trajectory_selector::valid_trajectory_filter


### PR DESCRIPTION
Before (odaiba map): 
ros2 topic echo /valid_trajectory_filter/debug/processing_time_detail_ms
nodes:
- id: 1
  name: process
  processing_time: 216.058
  parent_id: 0
  comment: ''
- id: 2
  name: traffic_light_check
  processing_time: 216.036
  parent_id: 1
  comment: ''
---
nodes:
- id: 1
  name: process
  processing_time: 236.775
  parent_id: 0
  comment: ''
- id: 2
  name: traffic_light_check
  processing_time: 236.752
  parent_id: 1
  comment: ''

After: 
nodes:
- id: 1
  name: process
  processing_time: 0.143
  parent_id: 0
  comment: ''
- id: 2
  name: traffic_light_check
  processing_time: 0.133
  parent_id: 1
  comment: ''
- id: 3
  name: get_lanelets_from_trajectory
  processing_time: 0.126
  parent_id: 2
  comment: ''
- id: 4
  name: get_lanelets_from_trajectory
  processing_time: 0.126
  parent_id: 3
  comment: ''
- id: 5
  name: getLaneletsFromPath
  processing_time: 0.124
  parent_id: 4
  comment: ''
- id: 6
  name: loop
  processing_time: 0.001
  parent_id: 2
  comment: ''
---
nodes:
- id: 1
  name: process
  processing_time: 0.234
  parent_id: 0
  comment: ''
- id: 2
  name: traffic_light_check
  processing_time: 0.222
  parent_id: 1
  comment: ''
- id: 3
  name: get_lanelets_from_trajectory
  processing_time: 0.21
  parent_id: 2
  comment: ''
- id: 4
  name: get_lanelets_from_trajectory
  processing_time: 0.21
  parent_id: 3
  comment: ''
- id: 5
  name: getLaneletsFromPath
  processing_time: 0.207
  parent_id: 4
  comment: ''
- id: 6
  name: loop
  processing_time: 0.002
  parent_id: 2
  comment: ''


