### PR TITLE
feat/support launching along no planning autoware

### DIFF
--- a/autoware_new_planning_launch/launch/autoware_new_planning.launch.xml
+++ b/autoware_new_planning_launch/launch/autoware_new_planning.launch.xml
@@ -3,12 +3,12 @@
   <arg name="map_path" description="point cloud and lanelet2 map directory path"/>
   <arg name="vehicle_model" description="vehicle model name"/>
   <arg name="sensor_model" description="sensor model name"/>
+  <arg name="mission_planner_param_path" default="$(find-pkg-share autoware_launch)/config/planning/mission_planning/mission_planner/mission_planner.param.yaml"/>
 
   <!-- option -->
   <arg name="use_sim_time" default="false" description="use_sim_time"/>
   <arg name="enable_all_modules_auto_mode" default="false" description="enable all module's auto mode"/>
   <arg name="is_simulation" default="false" description="Autoware's behavior will change depending on whether this is a simulation or not."/>
-  <arg name="mission_planner_param_path" default="$(find-pkg-share autoware_launch)/config/planning/mission_planning/mission_planner/mission_planner.param.yaml"/>
 
   <group scoped="false">
     <include file="$(find-pkg-share autoware_vehicle_info_utils)/launch/vehicle_info.launch.py">

--- a/autoware_new_planning_launch/launch/autoware_new_planning.launch.xml
+++ b/autoware_new_planning_launch/launch/autoware_new_planning.launch.xml
@@ -1,0 +1,49 @@
+<launch>
+  <!-- essential params -->
+  <arg name="map_path" description="point cloud and lanelet2 map directory path"/>
+  <arg name="vehicle_model" description="vehicle model name"/>
+  <arg name="sensor_model" description="sensor model name"/>
+
+  <!-- option -->
+  <arg name="use_sim_time" default="false" description="use_sim_time"/>
+  <arg name="enable_all_modules_auto_mode" default="false" description="enable all module's auto mode"/>
+  <arg name="is_simulation" default="false" description="Autoware's behavior will change depending on whether this is a simulation or not."/>
+  <arg name="mission_planner_param_path" default="$(find-pkg-share autoware_launch)/config/planning/mission_planning/mission_planner/mission_planner.param.yaml"/>
+
+  <group scoped="false">
+    <include file="$(find-pkg-share autoware_vehicle_info_utils)/launch/vehicle_info.launch.py">
+      <arg name="vehicle_info_param_file" value="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
+    </include>
+  </group>
+
+  <group>
+      <push-ros-namespace namespace="planning"/>
+      <push-ros-namespace namespace="mission_planning"/>
+      <include file="$(find-pkg-share tier4_planning_launch)/launch/mission_planning/mission_planning.launch.xml">
+        <arg name="mission_planner_param_path" value="$(var mission_planner_param_path)"/>
+      </include>
+  </group>
+
+
+
+  <!-- <group> -->
+  <!--   <push-ros-namespace namespace="planning/external_generator"/> -->
+  <!--   <include file="$(find-pkg-share autoware_new_planning_launch)/launch/sampling_base_planner.launch.xml"> -->
+  <!--     <arg name="vehicle_model" value="$(var vehicle_model)"/> -->
+  <!--   </include> -->
+  <!-- </group> -->
+
+  <group>
+    <include file="$(find-pkg-share autoware_new_planning_launch)/launch/temp_autoware_selector.launch.xml">
+      <arg name="vehicle_model" value="$(var vehicle_model)"/>
+      <arg name="use_dummy_trajectory" value="false"/>
+      <arg name="stand_alone" value="false"/>
+    </include>
+  </group>
+
+  <group>
+    <include file="$(find-pkg-share autoware_new_planning_launch)/launch/generator.launch.xml">
+      <arg name="map_path" value="$(var map_path)"/>
+    </include>
+  </group>
+</launch>

--- a/autoware_new_planning_launch/launch/autoware_new_planning.launch.xml
+++ b/autoware_new_planning_launch/launch/autoware_new_planning.launch.xml
@@ -24,15 +24,6 @@
       </include>
   </group>
 
-
-
-  <!-- <group> -->
-  <!--   <push-ros-namespace namespace="planning/external_generator"/> -->
-  <!--   <include file="$(find-pkg-share autoware_new_planning_launch)/launch/sampling_base_planner.launch.xml"> -->
-  <!--     <arg name="vehicle_model" value="$(var vehicle_model)"/> -->
-  <!--   </include> -->
-  <!-- </group> -->
-
   <group>
     <include file="$(find-pkg-share autoware_new_planning_launch)/launch/temp_autoware_selector.launch.xml">
       <arg name="vehicle_model" value="$(var vehicle_model)"/>

--- a/autoware_new_planning_launch/launch/temp_autoware_selector.launch.xml
+++ b/autoware_new_planning_launch/launch/temp_autoware_selector.launch.xml
@@ -1,0 +1,28 @@
+<launch>
+  <!-- essential params -->
+  <arg name="vehicle_model" description="vehicle model name"/>
+
+  <!-- param path -->
+  <arg name="dummy_trajectory_publisher_param_path" default="$(find-pkg-share autoware_dummy_trajectory_publisher)/config/dummy_trajectory_publisher.param.yaml"/>
+  <arg name="evaluator_weight_param_path" default="$(find-pkg-share autoware_trajectory_ranker)/config/evaluation.param.yaml"/>
+
+  <!-- topic name -->
+  <arg name="control_component_input" default="/planning/scenario_planning/trajectory"/>
+  <arg name="selector_component_input" default="/planning/candidate/trajectories"/>
+
+  <!-- option -->
+  <arg name="container_type" default="component_container_mt"/>
+  <arg name="stand_alone" default="true"/>
+  <arg name="use_dummy_trajectory" default="true"/>
+  <arg name="use_sim_time" default="false" description="use_sim_time"/>
+
+  <group if="$(var stand_alone)" scoped="false">
+    <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
+      <arg name="use_sim_time" value="$(var use_sim_time)"/>
+      <arg name="vehicle_model" value="$(var vehicle_model)"/>
+    </include>
+  </group>
+
+  <include file="$(find-pkg-share autoware_trajectory_adaptor)/launch/trajectory_adaptor.launch.xml">
+  </include>
+</launch>

--- a/autoware_new_planning_launch/launch/temp_autoware_selector.launch.xml
+++ b/autoware_new_planning_launch/launch/temp_autoware_selector.launch.xml
@@ -3,18 +3,16 @@
   <arg name="vehicle_model" description="vehicle model name"/>
 
   <!-- param path -->
-  <arg name="dummy_trajectory_publisher_param_path" default="$(find-pkg-share autoware_dummy_trajectory_publisher)/config/dummy_trajectory_publisher.param.yaml"/>
   <arg name="evaluator_weight_param_path" default="$(find-pkg-share autoware_trajectory_ranker)/config/evaluation.param.yaml"/>
 
   <!-- topic name -->
+  <arg name="input_trajectories_topic" default="/planning/trajectory_selector/concatenate/trajectories"/>
   <arg name="control_component_input" default="/planning/scenario_planning/trajectory"/>
   <arg name="selector_component_input" default="/planning/candidate/trajectories"/>
 
   <!-- option -->
   <arg name="container_type" default="component_container_mt"/>
   <arg name="stand_alone" default="true"/>
-  <arg name="use_dummy_trajectory" default="true"/>
-  <arg name="use_sim_time" default="false" description="use_sim_time"/>
 
   <group if="$(var stand_alone)" scoped="false">
     <include file="$(find-pkg-share global_parameter_loader)/launch/global_params.launch.py">
@@ -23,10 +21,19 @@
     </include>
   </group>
 
+
+<include file="$(find-pkg-share autoware_trajectory_ranker)/launch/trajectory_ranker.launch.xml">
+      <arg name="evaluator_weight_param_path" value="$(var evaluator_weight_param_path)"/>
+      <arg name="input_trajectories_topic" value="/planning/trajectory_selector/concatenate/trajectories"/>
+</include>
+
+
 <include file="$(find-pkg-share autoware_trajectory_concatenator)/launch/trajectory_concatenator.launch.xml">
-  </include>
-</launch>
+   <arg name="selector_component_input" value="$(var selector_component_input)"/>
+   <arg name="control_component_input" value="$(var control_component_input)"/>
+</include>
 
 <include file="$(find-pkg-share autoware_trajectory_adaptor)/launch/trajectory_adaptor.launch.xml">
+   <arg name="control_component_input" value="$(var control_component_input)"/>
   </include>
 </launch>

--- a/autoware_new_planning_launch/launch/temp_autoware_selector.launch.xml
+++ b/autoware_new_planning_launch/launch/temp_autoware_selector.launch.xml
@@ -23,6 +23,10 @@
     </include>
   </group>
 
-  <include file="$(find-pkg-share autoware_trajectory_adaptor)/launch/trajectory_adaptor.launch.xml">
+<include file="$(find-pkg-share autoware_trajectory_concatenator)/launch/trajectory_concatenator.launch.xml">
+  </include>
+</launch>
+
+<include file="$(find-pkg-share autoware_trajectory_adaptor)/launch/trajectory_adaptor.launch.xml">
   </include>
 </launch>

--- a/autoware_new_planning_launch/launch/temp_autoware_selector.launch.xml
+++ b/autoware_new_planning_launch/launch/temp_autoware_selector.launch.xml
@@ -21,19 +21,18 @@
     </include>
   </group>
 
-
-<include file="$(find-pkg-share autoware_trajectory_ranker)/launch/trajectory_ranker.launch.xml">
+  <!-- Add feasible and valid trajectory filters once they are fixed -->
+  <include file="$(find-pkg-share autoware_trajectory_ranker)/launch/trajectory_ranker.launch.xml">
       <arg name="evaluator_weight_param_path" value="$(var evaluator_weight_param_path)"/>
       <arg name="input_trajectories_topic" value="/planning/trajectory_selector/concatenate/trajectories"/>
-</include>
+  </include>
 
-
-<include file="$(find-pkg-share autoware_trajectory_concatenator)/launch/trajectory_concatenator.launch.xml">
+  <include file="$(find-pkg-share autoware_trajectory_concatenator)/launch/trajectory_concatenator.launch.xml">
    <arg name="selector_component_input" value="$(var selector_component_input)"/>
    <arg name="control_component_input" value="$(var control_component_input)"/>
-</include>
+  </include>
 
-<include file="$(find-pkg-share autoware_trajectory_adaptor)/launch/trajectory_adaptor.launch.xml">
+  <include file="$(find-pkg-share autoware_trajectory_adaptor)/launch/trajectory_adaptor.launch.xml">
    <arg name="control_component_input" value="$(var control_component_input)"/>
   </include>
-</launch>
+  </launch>

--- a/autoware_trajectory_adaptor/CMakeLists.txt
+++ b/autoware_trajectory_adaptor/CMakeLists.txt
@@ -17,4 +17,7 @@ rclcpp_components_register_node(${PROJECT_NAME}
   EXECUTABLE ${PROJECT_NAME}_node
 )
 
-ament_auto_package()
+ament_auto_package(
+  INSTALL_TO_SHARE
+  launch
+)

--- a/autoware_trajectory_adaptor/launch/trajectory_adaptor.launch.xml
+++ b/autoware_trajectory_adaptor/launch/trajectory_adaptor.launch.xml
@@ -2,7 +2,7 @@
 <launch>
 
   <node pkg="autoware_trajectory_adaptor" exec="autoware_trajectory_adaptor_node" name="trajectory_adaptor_node" output="screen">
-     <remap from="~/input/trajectories" to="/planning/candidate/trajectories"/>
+     <remap from="~/input/trajectories" to="/planning/trajectory_selector/scored/trajectories"/>
       <remap from="~/output/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
       <remap from="~/output/trajectory" to="$(var control_component_input)"/>
       <remap from="~/output/markers" to="/planning/trajectory_selector/markers"/>

--- a/autoware_trajectory_adaptor/launch/trajectory_adaptor.launch.xml
+++ b/autoware_trajectory_adaptor/launch/trajectory_adaptor.launch.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+
+  <node pkg="autoware_trajectory_adaptor" exec="autoware_trajectory_adaptor_node" name="trajectory_adaptor_node" output="screen">
+     <remap from="~/input/trajectories" to="/planning/candidate/trajectories"/>
+      <remap from="~/output/hazard_lights_cmd" to="/planning/hazard_lights_cmd"/>
+      <remap from="~/output/trajectory" to="$(var control_component_input)"/>
+      <remap from="~/output/markers" to="/planning/trajectory_selector/markers"/>
+  </node>
+</launch>

--- a/autoware_trajectory_concatenator/CMakeLists.txt
+++ b/autoware_trajectory_concatenator/CMakeLists.txt
@@ -29,4 +29,8 @@ rclcpp_components_register_node(${PROJECT_NAME}
   EXECUTABLE ${PROJECT_NAME}_node
 )
 
-ament_auto_package()
+ament_auto_package(
+  INSTALL_TO_SHARE
+  config
+  launch
+)

--- a/autoware_trajectory_concatenator/config/concatenator.param.yaml
+++ b/autoware_trajectory_concatenator/config/concatenator.param.yaml
@@ -4,5 +4,5 @@
 
     selected_trajectory:
       use: false
-      endpoint_time_min: 10 #[s]
+      endpoint_time_min: 10.0 #[s]
       extension_interval: 0.1 # [s]

--- a/autoware_trajectory_concatenator/launch/trajectory_concatenator.launch.xml
+++ b/autoware_trajectory_concatenator/launch/trajectory_concatenator.launch.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+
+  <arg name="selector_component_input" default="/planning/candidate/trajectories"/>
+  <arg name="trajectory_concatenator_param_path" default="$(find-pkg-share autoware_trajectory_concatenator)/config/trajectory_concatenator.param.yaml"/>
+
+  <node pkg="autoware_trajectory_concatenator" exec="autoware_trajectory_concatenator_node" name="trajectory_concatenator_node" output="screen">
+      <param from="$(var trajectory_concatenator_param_path)" allow_substs="true"/>
+      <remap from="~/input/trajectories" to="$(var selector_component_input)"/>
+      <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+      <remap from="~/input/selected_trajectory" to="$(var control_component_input)"/>
+      <remap from="~/output/trajectories" to="/planning/trajectory_selector/concatenate/trajectories"/>
+  </node>
+</launch>

--- a/autoware_trajectory_concatenator/launch/trajectory_concatenator.launch.xml
+++ b/autoware_trajectory_concatenator/launch/trajectory_concatenator.launch.xml
@@ -2,7 +2,7 @@
 <launch>
 
   <arg name="selector_component_input" default="/planning/candidate/trajectories"/>
-  <arg name="trajectory_concatenator_param_path" default="$(find-pkg-share autoware_trajectory_concatenator)/config/trajectory_concatenator.param.yaml"/>
+  <arg name="trajectory_concatenator_param_path" default="$(find-pkg-share autoware_trajectory_concatenator)/config/concatenator.param.yaml"/>
 
   <node pkg="autoware_trajectory_concatenator" exec="autoware_trajectory_concatenator_node" name="trajectory_concatenator_node" output="screen">
       <param from="$(var trajectory_concatenator_param_path)" allow_substs="true"/>

--- a/autoware_trajectory_ranker/CMakeLists.txt
+++ b/autoware_trajectory_ranker/CMakeLists.txt
@@ -32,4 +32,5 @@ rclcpp_components_register_node(${PROJECT_NAME}
 ament_auto_package(
   INSTALL_TO_SHARE
   config
+  launch
 )

--- a/autoware_trajectory_ranker/launch/trajectory_ranker.launch.xml
+++ b/autoware_trajectory_ranker/launch/trajectory_ranker.launch.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <arg name="trajectory_ranker_param_path" default="$(find-pkg-share autoware_trajectory_ranker)/config/evaluation.param.yaml"/>
+  <arg name="input_trajectories_topic" default="/planning/trajectory_selector/validated/trajectories"/>
+
+  <node pkg="autoware_trajectory_ranker" exec="autoware_trajectory_ranker_node" name="trajectory_ranker_node" output="screen">
+    <param from="$(var trajectory_ranker_param_path)" allow_substs="true"/>
+    <param from="$(var evaluator_weight_param_path)"/>
+
+      <!-- Disabled for now <remap from="~/input/trajectories" to="/planning/trajectory_selector/validated/trajectories"/> -->
+      <remap from="~/input/trajectories" to="$(var input_trajectories_topic)"/>
+      <remap from="~/output/trajectories" to="/planning/trajectory_selector/scored/trajectories"/>
+
+      <remap from="~/input/route" to="/planning/mission_planning/route"/>
+      <remap from="~/input/lanelet2_map" to="/map/vector_map"/>
+      <remap from="~/input/odometry" to="/localization/kinematic_state"/>
+      <remap from="~/input/objects" to="/perception/object_recognition/objects"/>
+      <remap from="~/input/steering" to="/vehicle/status/steering_status"/>
+      <remap from="~/output/markers" to="/planning/trajectory_selector/ranker/markers"/>
+  </node>
+</launch>


### PR DESCRIPTION
These launch files allow the user to launch regular autoware (with planning disabled) and the new planning framework on a separate terminal